### PR TITLE
fix: re-sign self-signed builds to fix repeated TCC permission prompts (closes #6)

### DIFF
--- a/justfile
+++ b/justfile
@@ -50,7 +50,11 @@ build-release:
 # Self-signed build (no developer account needed)
 build-self-signed:
     @echo "🔨 Building {{app_name}} (Release)..."
-    xcodebuild -scheme {{scheme}} -configuration Release -derivedDataPath DerivedData build
+    xcodebuild -scheme {{scheme}} -configuration Release -derivedDataPath DerivedData \
+        CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
+        build
+    @echo "🔏 Re-signing with adhoc identity (required for macOS TCC permissions)..."
+    codesign --force --deep --sign - {{app_bundle}}
     @echo "✅ Self-signed build complete"
 
 # Self-signed DMG (no developer account needed)


### PR DESCRIPTION
## Problem

Fixes #6 — users building from source (or running the self-signed DMG) experience macOS looping and repeatedly asking for Microphone and/or Accessibility permissions on every launch.

## Root Cause

The `build-self-signed` recipe called `xcodebuild` without explicitly disabling code signing. When no developer certificate is present, the linker falls back to a **linker-signed** adhoc signature (`flags=0x20002, adhoc,linker-signed`). This is the bare minimum stamp the linker applies — it does **not** bind the `Info.plist` or seal app resources:

```
Signature=adhoc
Info.plist=not bound      ← the problem
Sealed Resources=none     ← the problem
```

macOS TCC (Transparency, Consent, and Control) uses the code signature — specifically the bound bundle identifier — to persist permission grants in its database. With an unbound `Info.plist`, macOS cannot reliably match the running app to its stored TCC entry, so it treats every launch as a new app and re-prompts for permissions.

## How I Found It

I built v1.7.0 from source and immediately hit the repeated Accessibility permission loop described in #6 — confirming the bug lives in the build process, not just the released binary.

## Fix

Explicitly disable Xcode signing (which would error without a cert) and then re-sign with `codesign --force --deep --sign -` to produce a proper adhoc signature:

```
Signature=adhoc
Info.plist entries=27     ← now bound
Sealed Resources version=2, rules=13, files=6  ← now sealed
```

This is all adhoc (no Apple Developer account required), but it gives TCC enough identity information to persist permission grants correctly across launches.

## Testing

Built from source on macOS 15 (Sequoia), Apple Silicon. After applying the fix:
- Granted Accessibility permission once
- Relaunched multiple times — permission was not re-requested

Made with [Cursor](https://cursor.com)