### PR TITLE
feat(output): enable dual-destination transcription (clipboard + direct insert)

### DIFF
--- a/Pindrop/AppCoordinator.swift
+++ b/Pindrop/AppCoordinator.swift
@@ -359,7 +359,7 @@ final class AppCoordinator {
         self.settingsStore = SettingsStore()
         self.audioRecorder.setPreferredInputDeviceUID(settingsStore.selectedInputDeviceUID)
         
-        let initialOutputMode: OutputMode = settingsStore.outputMode == "directInsert" ? .directInsert : .clipboard
+        let initialOutputMode = OutputMode.fromStoredValue(settingsStore.outputMode)
         self.outputManager = OutputManager(outputMode: initialOutputMode)
         self.historyStore = HistoryStore(modelContext: modelContext)
         self.dictionaryStore = DictionaryStore(modelContext: modelContext)
@@ -439,8 +439,12 @@ final class AppCoordinator {
             await self?.handleCancelOperation()
         }
 
-        self.statusBarController.onToggleOutputMode = { [weak self] in
-            self?.handleToggleOutputMode()
+        self.statusBarController.onToggleClipboardOutput = { [weak self] in
+            self?.handleToggleClipboardOutput()
+        }
+
+        self.statusBarController.onToggleDirectInsertOutput = { [weak self] in
+            self?.handleToggleDirectInsertOutput()
         }
 
         self.statusBarController.onToggleAIControlled = { [weak self] in
@@ -1146,9 +1150,9 @@ final class AppCoordinator {
                     self.lastObservedSettingsSnapshot = snapshot
 
                     if previousSnapshot.outputMode != snapshot.outputMode {
-                        let mode: OutputMode = snapshot.outputMode == "clipboard" ? .clipboard : .directInsert
+                        let mode = OutputMode.fromStoredValue(snapshot.outputMode)
                         self.outputManager.setOutputMode(mode)
-                        if mode == .directInsert {
+                        if mode.contains(.directInsert) {
                             self.ensureAccessibilityPermissionForDirectInsert(trigger: "settings-change", showFallbackAlert: true)
                         }
                     }
@@ -2051,7 +2055,7 @@ final class AppCoordinator {
         isQuickCaptureMode: Bool
     ) -> Bool {
         streamingFeatureEnabled &&
-            outputMode == .directInsert &&
+            outputMode.contains(.directInsert) &&
             !aiEnhancementEnabled &&
             !isQuickCaptureMode
     }
@@ -2112,7 +2116,7 @@ final class AppCoordinator {
         guard shouldUseStreaming else {
             let reasons = [
                 settingsStore.streamingFeatureEnabled ? nil : "feature-disabled",
-                outputManager.outputMode == .directInsert ? nil : "output-mode-not-directInsert",
+                outputManager.outputMode.contains(.directInsert) ? nil : "output-mode-not-directInsert",
                 settingsStore.aiEnhancementEnabled ? "ai-enhancement-enabled" : nil,
                 isQuickCaptureMode ? "quick-capture-mode" : nil
             ].compactMap { $0 }
@@ -2627,7 +2631,7 @@ final class AppCoordinator {
 
         var outputSucceeded = false
         do {
-            if outputManager.outputMode == .directInsert {
+            if outputManager.outputMode.contains(.directInsert) {
                 ensureAccessibilityPermissionForDirectInsert(trigger: "output", showFallbackAlert: true)
             }
             let outputText = settingsStore.addTrailingSpace ? finalText + " " : finalText
@@ -3472,14 +3476,33 @@ final class AppCoordinator {
 
     // MARK: - Toggle Output Mode
 
-    private func handleToggleOutputMode() {
-        let newMode = settingsStore.outputMode == "clipboard" ? "directInsert" : "clipboard"
-        settingsStore.outputMode = newMode
-        Log.app.info("Output mode changed to: \(newMode)")
+    private func handleToggleClipboardOutput() {
+        toggleOutputDestination(.clipboard)
+    }
+
+    private func handleToggleDirectInsertOutput() {
+        toggleOutputDestination(.directInsert)
+    }
+
+    private func toggleOutputDestination(_ destination: OutputMode) {
+        var mode = OutputMode.fromStoredValue(settingsStore.outputMode)
+
+        if mode.contains(destination) {
+            mode.remove(destination)
+            if mode.isEmpty {
+                mode.insert(destination)
+                return
+            }
+        } else {
+            mode.insert(destination)
+        }
+
+        settingsStore.outputMode = mode.storedValue
+        Log.app.info("Output mode changed to: \(mode.displayName)")
     }
 
     private func ensureAccessibilityPermissionForDirectInsert(trigger: String, showFallbackAlert: Bool) {
-        guard outputManager.outputMode == .directInsert else { return }
+        guard outputManager.outputMode.contains(.directInsert) else { return }
 
         let hasPermission = permissionManager.checkAccessibilityPermission()
         if hasPermission {

--- a/Pindrop/Services/OutputManager.swift
+++ b/Pindrop/Services/OutputManager.swift
@@ -10,9 +10,60 @@ import AppKit
 import ApplicationServices
 import os.log
 
-enum OutputMode {
-    case clipboard
-    case directInsert
+struct OutputMode: OptionSet, CustomStringConvertible {
+    let rawValue: Int
+    
+    static let clipboard = OutputMode(rawValue: 1 << 0)
+    static let directInsert = OutputMode(rawValue: 1 << 1)
+    static let `default`: OutputMode = [.clipboard]
+    
+    var description: String {
+        displayName
+    }
+    
+    var displayName: String {
+        let hasClipboard = contains(.clipboard)
+        let hasDirectInsert = contains(.directInsert)
+
+        if hasClipboard && hasDirectInsert {
+            return "Clipboard + Direct Insert"
+        }
+        if hasClipboard {
+            return "Clipboard"
+        }
+        if hasDirectInsert {
+            return "Direct Insert"
+        }
+        return "Unknown"
+    }
+    
+    var storedValue: String {
+        var values: [String] = []
+        if contains(.clipboard) {
+            values.append("clipboard")
+        }
+        if contains(.directInsert) {
+            values.append("directInsert")
+        }
+        return values.joined(separator: ",")
+    }
+    
+    static func fromStoredValue(_ storedValue: String) -> OutputMode {
+        var mode: OutputMode = []
+        for token in storedValue
+            .split(separator: ",")
+            .map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) }) {
+            switch token {
+            case "clipboard":
+                mode.insert(.clipboard)
+            case "directInsert":
+                mode.insert(.directInsert)
+            default:
+                continue
+            }
+        }
+        return mode.isEmpty ? .default : mode
+    }
 }
 
 enum OutputManagerError: Error, LocalizedError {
@@ -126,12 +177,17 @@ final class OutputManager {
         }
         
         Log.output.debug("Output called, mode: \(String(describing: self.outputMode)), length: \(text.count)")
-        
-        switch outputMode {
-        case .clipboard:
+
+        let shouldCopyToClipboard = outputMode.contains(.clipboard)
+        let shouldDirectInsert = outputMode.contains(.directInsert)
+
+        if shouldDirectInsert {
+            try await pasteViaClipboard(text, restoreClipboard: !shouldCopyToClipboard)
+            return
+        }
+
+        if shouldCopyToClipboard {
             try copyToClipboard(text)
-        case .directInsert:
-            try await pasteViaClipboard(text, restoreClipboard: true)
         }
     }
 

--- a/Pindrop/UI/Settings/GeneralSettingsView.swift
+++ b/Pindrop/UI/Settings/GeneralSettingsView.swift
@@ -28,8 +28,8 @@ struct GeneralSettingsView: View {
                 ForEach(OutputOption.allCases) { option in
                     OutputOptionRow(
                         option: option,
-                        isSelected: settings.outputMode == option.rawValue,
-                        onSelect: { settings.outputMode = option.rawValue }
+                        isSelected: selectedOutputOptions.contains(option),
+                        onToggle: { toggleOutputOption(option) }
                     )
                 }
                 
@@ -52,6 +52,21 @@ struct GeneralSettingsView: View {
                 }
             }
         }
+    }
+    
+    private var selectedOutputOptions: Set<OutputOption> {
+        OutputOption.fromStoredValue(settings.outputMode)
+    }
+    
+    private func toggleOutputOption(_ option: OutputOption) {
+        var options = selectedOutputOptions
+        if options.contains(option) {
+            guard options.count > 1 else { return }
+            options.remove(option)
+        } else {
+            options.insert(option)
+        }
+        settings.outputMode = OutputOption.toStoredValue(options)
     }
     
     private var interfaceSection: some View {
@@ -251,27 +266,40 @@ enum OutputOption: String, CaseIterable, Identifiable {
         case .directInsert: return .textCursor
         }
     }
+    
+    static func fromStoredValue(_ storedValue: String) -> Set<OutputOption> {
+        let options = Set(
+            storedValue
+                .split(separator: ",")
+                .compactMap { Self(rawValue: $0.trimmingCharacters(in: .whitespacesAndNewlines)) }
+        )
+        return options.isEmpty ? [.clipboard] : options
+    }
+    
+    static func toStoredValue(_ options: Set<OutputOption>) -> String {
+        var storedValues: [String] = []
+        if options.contains(.clipboard) {
+            storedValues.append(OutputOption.clipboard.rawValue)
+        }
+        if options.contains(.directInsert) {
+            storedValues.append(OutputOption.directInsert.rawValue)
+        }
+        return storedValues.joined(separator: ",")
+    }
 }
 
 struct OutputOptionRow: View {
     let option: OutputOption
     let isSelected: Bool
-    let onSelect: () -> Void
+    let onToggle: () -> Void
     
     var body: some View {
-        Button(action: onSelect) {
+        Button(action: onToggle) {
             HStack(spacing: 12) {
-                ZStack {
-                    Circle()
-                        .stroke(isSelected ? AppColors.accent : Color.secondary.opacity(0.3), lineWidth: 2)
-                        .frame(width: 20, height: 20)
-                    
-                    if isSelected {
-                        Circle()
-                            .fill(AppColors.accent)
-                            .frame(width: 12, height: 12)
-                    }
-                }
+                Image(systemName: isSelected ? "checkmark.square.fill" : "square")
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundStyle(isSelected ? AppColors.accent : .secondary)
+                    .frame(width: 20, height: 20)
                 
                 IconView(icon: option.icon, size: 16)
                     .foregroundStyle(isSelected ? AppColors.accent : .secondary)

--- a/Pindrop/UI/StatusBarController.swift
+++ b/Pindrop/UI/StatusBarController.swift
@@ -34,7 +34,8 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     private var exportLastTranscriptItem: NSMenuItem?
     private var recentTranscriptsSeparator: NSMenuItem?
 
-    private var outputModeItem: NSMenuItem?
+    private var clipboardOutputItem: NSMenuItem?
+    private var directInsertOutputItem: NSMenuItem?
     private var aiEnhancementItem: NSMenuItem?
     private var promptPresetMenuItem: NSMenuItem?
     private var promptPresetMenu: NSMenu?
@@ -67,7 +68,8 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     var onExportLastTranscript: (() async -> Void)?
     var onClearAudioBuffer: (() async -> Void)?
     var onCancelOperation: (() async -> Void)?
-    var onToggleOutputMode: (() -> Void)?
+    var onToggleClipboardOutput: (() -> Void)?
+    var onToggleDirectInsertOutput: (() -> Void)?
     var onToggleAIControlled: (() -> Void)?
     var onSelectPromptPreset: ((String?) -> Void)?
     var onToggleFloatingIndicator: (() -> Void)?
@@ -252,14 +254,23 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         let outputHeader = createHeaderItem("Output")
         menu.addItem(outputHeader)
 
-        outputModeItem = NSMenuItem(
-            title: "Mode: Clipboard",
-            action: #selector(toggleOutputMode),
-            keyEquivalent: "o"
+        clipboardOutputItem = NSMenuItem(
+            title: "Clipboard",
+            action: #selector(toggleClipboardOutput),
+            keyEquivalent: ""
         )
-        outputModeItem?.target = self
-        outputModeItem?.image = NSImage(systemSymbolName: "doc.on.clipboard", accessibilityDescription: nil)
-        menu.addItem(outputModeItem!)
+        clipboardOutputItem?.target = self
+        clipboardOutputItem?.image = NSImage(systemSymbolName: "doc.on.clipboard", accessibilityDescription: nil)
+        menu.addItem(clipboardOutputItem!)
+
+        directInsertOutputItem = NSMenuItem(
+            title: "Direct Insert",
+            action: #selector(toggleDirectInsertOutput),
+            keyEquivalent: ""
+        )
+        directInsertOutputItem?.target = self
+        directInsertOutputItem?.image = NSImage(systemSymbolName: "text.cursor", accessibilityDescription: nil)
+        menu.addItem(directInsertOutputItem!)
 
         aiEnhancementItem = NSMenuItem(
             title: "AI Enhancement: Off",
@@ -483,9 +494,10 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     }
 
     func updateDynamicItems() {
-        // Update output mode
-        let outputModeText = settingsStore.outputMode == "clipboard" ? "Clipboard" : "Direct Insert"
-        outputModeItem?.title = "Mode: \(outputModeText)"
+        // Update output mode toggles
+        let outputMode = OutputMode.fromStoredValue(settingsStore.outputMode)
+        clipboardOutputItem?.state = outputMode.contains(.clipboard) ? .on : .off
+        directInsertOutputItem?.state = outputMode.contains(.directInsert) ? .on : .off
 
         // Update AI enhancement
         let aiText = settingsStore.aiEnhancementEnabled ? "On" : "Off"
@@ -757,8 +769,12 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         }
     }
 
-    @objc private func toggleOutputMode() {
-        onToggleOutputMode?()
+    @objc private func toggleClipboardOutput() {
+        onToggleClipboardOutput?()
+    }
+
+    @objc private func toggleDirectInsertOutput() {
+        onToggleDirectInsertOutput?()
     }
 
     @objc private func toggleAIEnhancement() {

--- a/PindropTests/OutputManagerTests.swift
+++ b/PindropTests/OutputManagerTests.swift
@@ -78,6 +78,9 @@ final class OutputManagerTests: XCTestCase {
         
         outputManager.setOutputMode(.clipboard)
         XCTAssertEqual(outputManager.outputMode, .clipboard)
+
+        outputManager.setOutputMode([.clipboard, .directInsert])
+        XCTAssertEqual(outputManager.outputMode, [.clipboard, .directInsert])
     }
     
     func testCopyToClipboard() throws {
@@ -220,6 +223,29 @@ final class OutputManagerTests: XCTestCase {
         XCTAssertEqual(mockClipboard.clipboardContent, testText)
         XCTAssertFalse(mockKeySimulation.pasteSimulated)
         XCTAssertEqual(mockClipboard.clearCount, 0)
+    }
+    
+    func testCombinedModePastesAndKeepsTranscriptionInClipboard() async throws {
+        outputManager.setOutputMode([.clipboard, .directInsert])
+        let testText = "Combined mode test"
+        let previousContent = "Previous content"
+        
+        mockClipboard.clipboardContent = previousContent
+        
+        try await outputManager.output(testText)
+        
+        XCTAssertTrue(mockKeySimulation.pasteSimulated)
+        XCTAssertEqual(mockClipboard.copiedText, testText)
+        XCTAssertEqual(mockClipboard.clipboardContent, testText)
+        XCTAssertEqual(mockClipboard.clearCount, 1)
+    }
+    
+    func testOutputModeStoredValueRoundTrip() {
+        XCTAssertEqual(OutputMode.fromStoredValue("clipboard"), [.clipboard])
+        XCTAssertEqual(OutputMode.fromStoredValue("directInsert"), [.directInsert])
+        XCTAssertEqual(OutputMode.fromStoredValue("clipboard,directInsert"), [.clipboard, .directInsert])
+        XCTAssertEqual(OutputMode.fromStoredValue("directInsert,clipboard").storedValue, "clipboard,directInsert")
+        XCTAssertEqual(OutputMode.fromStoredValue(""), .clipboard)
     }
     
     func testGetKeyCodeForBasicCharacters() {

--- a/PindropTests/SettingsStoreTests.swift
+++ b/PindropTests/SettingsStoreTests.swift
@@ -45,6 +45,9 @@ final class SettingsStoreTests: XCTestCase {
         settingsStore.outputMode = "directInsert"
         XCTAssertEqual(settingsStore.outputMode, "directInsert")
         
+        settingsStore.outputMode = "clipboard,directInsert"
+        XCTAssertEqual(settingsStore.outputMode, "clipboard,directInsert")
+        
         settingsStore.aiEnhancementEnabled = true
         XCTAssertTrue(settingsStore.aiEnhancementEnabled)
         
@@ -52,7 +55,7 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(newStore.selectedModel, "large-v3")
         XCTAssertEqual(newStore.toggleHotkey, "⌘⇧A")
         XCTAssertEqual(newStore.pushToTalkHotkey, "⌘⇧B")
-        XCTAssertEqual(newStore.outputMode, "directInsert")
+        XCTAssertEqual(newStore.outputMode, "clipboard,directInsert")
         XCTAssertTrue(newStore.aiEnhancementEnabled)
         
         settingsStore.selectedModel = "base"


### PR DESCRIPTION
## Summary

This PR adds **dual-destination transcription output** so transcription can be sent to:

- Clipboard
- Direct insert at cursor
- **Both at the same time** (new behavior)

Previously output mode behaved as a single-choice mode. It now supports independent toggles so users can enable clipboard and direct-insert simultaneously.

## What Changed

- Reworked output behavior to support dual destination delivery.
- Updated settings UI to use independent toggles for:
  - Clipboard output
  - Direct-insert output
- Updated status bar menu output controls to match the same toggle model (no single mode switch).
- Updated app coordination/output flow so a completed transcription can:
  - copy to clipboard, and
  - attempt direct insert into the focused input
  in the same run.
- Added/updated tests for output and settings behavior around dual-destination handling.

## Why

Users often want a pasted result immediately in the active input while still keeping the same transcription in clipboard for fallback/reuse. This PR enables that workflow directly.

## How To Test

1. Enable both output toggles (Clipboard + Direct Insert) in Settings.
2. Focus any text input field in another app.
3. Start/stop recording and wait for transcription.
4. Verify:
   - Text is inserted at the cursor in the focused app.
   - The same text is available in clipboard.
5. Disable Direct Insert, keep Clipboard on:
   - Verify only clipboard is updated.
6. Disable Clipboard, keep Direct Insert on:
   - Verify only direct insertion occurs.
7. Toggle from the status bar menu and repeat to confirm behavior matches Settings UI.

## Validation Run

- Build:
  - `xcodebuild build -scheme Pindrop -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
- Test:
  - `xcodebuild test -scheme Pindrop -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`

Both commands succeeded locally.

## Screenshots

- Settings screen showing both output toggles enabled.
- Status bar menu showing separate output toggles.
- (Optional) short GIF showing insert + clipboard behavior in one recording cycle.

## Related Issues

- Closes #28 