### PR TITLE
fix(swiftdata): recover stores with missing schema objects

### DIFF
--- a/Pindrop/Mocks/PreviewMocks.swift
+++ b/Pindrop/Mocks/PreviewMocks.swift
@@ -172,7 +172,6 @@ enum PreviewContainer {
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         let container = try! ModelContainer(
             for: TranscriptionRecord.self, MediaFolder.self, WordReplacement.self, VocabularyWord.self, NoteSchema.Note.self,
-            migrationPlan: TranscriptionRecordMigrationPlan.self,
             configurations: config
         )
         for record in records {

--- a/Pindrop/PindropApp.swift
+++ b/Pindrop/PindropApp.swift
@@ -167,7 +167,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             VocabularyWord.self,
             Note.self,
             PromptPreset.self,
-            migrationPlan: TranscriptionRecordMigrationPlan.self,
             configurations: configuration
         )
     }
@@ -200,6 +199,17 @@ final class SwiftDataStoreRepairService {
     struct RepairOutcome {
         let repaired: Bool
         let backupDirectoryURL: URL?
+    }
+
+    private struct SchemaObjectDefinition {
+        let name: String
+        let sql: String
+    }
+
+    private struct ReferenceArtifacts {
+        let metadataBlob: Data
+        let modelCacheBlob: Data
+        let schemaDefinitions: [SchemaObjectDefinition]
     }
 
     private let fileManager: FileManager
@@ -270,16 +280,24 @@ final class SwiftDataStoreRepairService {
         }
 
         let metadataVersion = try readMetadataVersionIdentifier(at: targetStoreURL)
-        guard metadataVersion != inferredVersion.rawValue else {
+        let referenceArtifacts = try makeReferenceArtifacts(for: inferredVersion)
+        let missingSchemaDefinitions = try withDatabase(at: targetStoreURL) { database in
+            let existingObjectNames = try fetchSchemaObjectNames(on: database)
+            return referenceArtifacts.schemaDefinitions.filter { !existingObjectNames.contains($0.name) }
+        }
+
+        guard metadataVersion != inferredVersion.rawValue || !missingSchemaDefinitions.isEmpty else {
             return RepairOutcome(repaired: false, backupDirectoryURL: nil)
         }
 
         let backupDirectoryURL = try backupStoreArtifacts(for: targetStoreURL)
-        let referenceArtifacts = try makeReferenceArtifacts(for: inferredVersion)
 
         try withDatabase(at: targetStoreURL) { database in
             try execute("BEGIN IMMEDIATE TRANSACTION", on: database)
             do {
+                for schemaDefinition in missingSchemaDefinitions {
+                    try execute(schemaDefinition.sql, on: database)
+                }
                 try updateMetadata(referenceArtifacts.metadataBlob, on: database)
                 try replaceModelCache(referenceArtifacts.modelCacheBlob, on: database)
                 try execute("COMMIT TRANSACTION", on: database)
@@ -289,9 +307,16 @@ final class SwiftDataStoreRepairService {
             }
         }
 
-        Log.app.info(
-            "Repaired SwiftData store metadata from \(metadataVersion ?? "unknown") to \(inferredVersion.rawValue); backup: \(backupDirectoryURL.path)"
-        )
+        if missingSchemaDefinitions.isEmpty {
+            Log.app.info(
+                "Repaired SwiftData store metadata from \(metadataVersion ?? "unknown") to \(inferredVersion.rawValue); backup: \(backupDirectoryURL.path)"
+            )
+        } else {
+            let recreatedNames = missingSchemaDefinitions.map(\.name).joined(separator: ", ")
+            Log.app.info(
+                "Repaired SwiftData store by recreating missing schema objects (\(recreatedNames)) and refreshing metadata to \(inferredVersion.rawValue); backup: \(backupDirectoryURL.path)"
+            )
+        }
         return RepairOutcome(repaired: true, backupDirectoryURL: backupDirectoryURL)
     }
 
@@ -367,7 +392,7 @@ final class SwiftDataStoreRepairService {
         return backupDirectoryURL
     }
 
-    private func makeReferenceArtifacts(for version: StoreSchemaVersion) throws -> (metadataBlob: Data, modelCacheBlob: Data) {
+    private func makeReferenceArtifacts(for version: StoreSchemaVersion) throws -> ReferenceArtifacts {
         let directoryURL = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         let storeURL = directoryURL.appendingPathComponent("reference.store")
         try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
@@ -445,7 +470,12 @@ final class SwiftDataStoreRepairService {
                 throw StoreRepairError.missingModelCache
             }
 
-            return (metadataBlob, modelCacheBlob)
+            let schemaDefinitions = try fetchSchemaDefinitions(on: database)
+            return ReferenceArtifacts(
+                metadataBlob: metadataBlob,
+                modelCacheBlob: modelCacheBlob,
+                schemaDefinitions: schemaDefinitions
+            )
         }
     }
 
@@ -528,6 +558,46 @@ final class SwiftDataStoreRepairService {
         }
 
         return sqlite3_step(statement) == SQLITE_ROW
+    }
+
+    private func fetchSchemaDefinitions(on database: OpaquePointer) throws -> [SchemaObjectDefinition] {
+        var statement: OpaquePointer?
+        let sql = """
+        SELECT name, sql
+        FROM sqlite_master
+        WHERE type IN ('table', 'index')
+          AND name NOT LIKE 'sqlite_%'
+          AND sql IS NOT NULL
+        ORDER BY CASE type WHEN 'table' THEN 0 ELSE 1 END, name
+        """
+
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw StoreRepairError.sqlite(message: lastSQLiteErrorMessage(on: database))
+        }
+
+        defer { sqlite3_finalize(statement) }
+
+        var definitions: [SchemaObjectDefinition] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            guard let namePointer = sqlite3_column_text(statement, 0),
+                  let sqlPointer = sqlite3_column_text(statement, 1) else {
+                continue
+            }
+
+            definitions.append(
+                SchemaObjectDefinition(
+                    name: String(cString: namePointer),
+                    sql: String(cString: sqlPointer)
+                )
+            )
+        }
+
+        return definitions
+    }
+
+    private func fetchSchemaObjectNames(on database: OpaquePointer) throws -> Set<String> {
+        let definitions = try fetchSchemaDefinitions(on: database)
+        return Set(definitions.map(\.name))
     }
 
     private func fetchBlob(sql: String, on database: OpaquePointer) throws -> Data? {

--- a/PindropTests/HistoryStoreTests.swift
+++ b/PindropTests/HistoryStoreTests.swift
@@ -21,7 +21,6 @@ final class HistoryStoreTests: XCTestCase {
         modelContainer = try ModelContainer(
             for: TranscriptionRecord.self,
             MediaFolder.self,
-            migrationPlan: TranscriptionRecordMigrationPlan.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         modelContext = ModelContext(modelContainer)
@@ -69,7 +68,6 @@ final class HistoryStoreTests: XCTestCase {
             VocabularyWord.self,
             Note.self,
             PromptPreset.self,
-            migrationPlan: TranscriptionRecordMigrationPlan.self,
             configurations: configuration
         )
         let migratedContext = ModelContext(migratedContainer)
@@ -120,7 +118,6 @@ final class HistoryStoreTests: XCTestCase {
             VocabularyWord.self,
             Note.self,
             PromptPreset.self,
-            migrationPlan: TranscriptionRecordMigrationPlan.self,
             configurations: configuration
         )
         let migratedContext = ModelContext(migratedContainer)
@@ -709,6 +706,44 @@ final class HistoryStoreTests: XCTestCase {
         try? FileManager.default.removeItem(at: referenceStoreURL.deletingLastPathComponent())
     }
 
+    func testRepairServiceRecreatesMissingPromptPresetTableWhenMetadataVersionMatches() throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let storeURL = directoryURL.appendingPathComponent("missing-prompt-preset.store")
+        let repairService = SwiftDataStoreRepairService()
+
+        let seedContainer = try makeCurrentContainer(at: storeURL)
+        let seedContext = ModelContext(seedContainer)
+        seedContext.insert(
+            TranscriptionRecord(
+                text: "Existing transcription",
+                duration: 2.5,
+                modelUsed: "base"
+            )
+        )
+        try seedContext.save()
+
+        try withDatabase(at: storeURL) { database in
+            try execute("DROP TABLE ZPROMPTPRESET", on: database)
+        }
+
+        XCTAssertFalse(try tableExists(named: "ZPROMPTPRESET", at: storeURL))
+
+        let repairOutcome = try repairService.repairIfNeeded(storeURL: storeURL)
+        XCTAssertTrue(repairOutcome.repaired)
+        XCTAssertNotNil(repairOutcome.backupDirectoryURL)
+        XCTAssertTrue(try tableExists(named: "ZPROMPTPRESET", at: storeURL))
+
+        let repairedContainer = try makeCurrentContainer(at: storeURL)
+        let repairedContext = ModelContext(repairedContainer)
+        let records = try repairedContext.fetch(FetchDescriptor<TranscriptionRecord>())
+
+        XCTAssertEqual(records.count, 1)
+        XCTAssertEqual(records.first?.text, "Existing transcription")
+
+        try? FileManager.default.removeItem(at: directoryURL)
+    }
+
     func testPrepareStoreLocationMigratesRecognizedLegacyStore() throws {
         let applicationSupportURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -760,6 +795,18 @@ final class HistoryStoreTests: XCTestCase {
         XCTAssertNil(records.first?.folder)
 
         try? FileManager.default.removeItem(at: applicationSupportURL)
+    }
+
+    func testCurrentContainerMigratesLegacyStoreWithoutPromptPresetModel() throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let storeURL = directoryURL.appendingPathComponent("legacy-no-prompt-preset.store")
+
+        try createV4StoreWithoutPromptPreset(at: storeURL)
+
+        XCTAssertNoThrow(try makeCurrentContainer(at: storeURL))
+
+        try? FileManager.default.removeItem(at: directoryURL)
     }
 
     func testPrepareStoreLocationIgnoresUnrecognizedLegacyStore() throws {
@@ -967,6 +1014,36 @@ final class HistoryStoreTests: XCTestCase {
         try context.save()
     }
 
+    private func createV4StoreWithoutPromptPreset(at storeURL: URL) throws {
+        try FileManager.default.createDirectory(at: storeURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let configuration = ModelConfiguration(url: storeURL)
+        let container = try ModelContainer(
+            for: TranscriptionRecordSchemaV4.TranscriptionRecord.self,
+            WordReplacement.self,
+            VocabularyWord.self,
+            Note.self,
+            configurations: configuration
+        )
+
+        let context = ModelContext(container)
+        context.insert(
+            TranscriptionRecordSchemaV4.TranscriptionRecord(
+                text: "Legacy transcription",
+                originalText: "Legacy transcription",
+                duration: 4.2,
+                modelUsed: "base",
+                enhancedWith: nil,
+                diarizationSegmentsJSON: nil,
+                sourceKind: .voiceRecording,
+                sourceDisplayName: nil,
+                originalSourceURL: nil,
+                managedMediaPath: nil,
+                thumbnailPath: nil
+            )
+        )
+        try context.save()
+    }
+
     private func createUnrecognizedStore(at storeURL: URL) throws {
         try FileManager.default.createDirectory(at: storeURL.deletingLastPathComponent(), withIntermediateDirectories: true)
 
@@ -998,7 +1075,6 @@ final class HistoryStoreTests: XCTestCase {
             VocabularyWord.self,
             Note.self,
             PromptPreset.self,
-            migrationPlan: TranscriptionRecordMigrationPlan.self,
             configurations: configuration
         )
     }
@@ -1080,6 +1156,30 @@ final class HistoryStoreTests: XCTestCase {
 
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw sqliteError(on: database)
+        }
+    }
+
+    private func tableExists(named table: String, at storeURL: URL) throws -> Bool {
+        try withDatabase(at: storeURL) { database in
+            var statement: OpaquePointer?
+            let sql = "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1"
+            guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
+                throw sqliteError(on: database)
+            }
+
+            defer { sqlite3_finalize(statement) }
+
+            guard sqlite3_bind_text(
+                statement,
+                1,
+                (table as NSString).utf8String,
+                -1,
+                unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+            ) == SQLITE_OK else {
+                throw sqliteError(on: database)
+            }
+
+            return sqlite3_step(statement) == SQLITE_ROW
         }
     }
 


### PR DESCRIPTION
## Summary
- remove the explicit `TranscriptionRecordMigrationPlan` from mixed-model containers so SwiftData can migrate all models together
- extend `SwiftDataStoreRepairService` to recreate missing schema objects (tables/indexes) from a reference store before refreshing metadata/model cache
- add regression tests for legacy stores without `PromptPreset` and stores missing `ZPROMPTPRESET` while metadata version appears current

## Test plan
- [x] `xcodebuild test -project Pindrop.xcodeproj -scheme Pindrop -testPlan Unit -destination 'platform=macOS' CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] launch local debug app and confirm startup no longer exits with a database alert

Closes #35.