### PR TITLE
feat(models): add all missing WhisperKit CoreML models (Medium, Large v2, quantized, Distil-Whisper)

### DIFF
--- a/Pindrop/Services/ModelManager.swift
+++ b/Pindrop/Services/ModelManager.swift
@@ -162,6 +162,15 @@ class ModelManager {
             language: .multilingual
         ),
         WhisperModel(
+            name: "openai_whisper-small_216MB",
+            displayName: "Whisper Small (Quantized)",
+            sizeInMB: 216,
+            description: "Quantized small model — half the size with similar accuracy",
+            speedRating: 8.0,
+            accuracyRating: 7.8,
+            language: .multilingual
+        ),
+        WhisperModel(
             name: "openai_whisper-small.en",
             displayName: "Whisper Small (English)",
             sizeInMB: 483,
@@ -169,6 +178,69 @@ class ModelManager {
             speedRating: 7.5,
             accuracyRating: 8.5,
             language: .english
+        ),
+        WhisperModel(
+            name: "openai_whisper-small.en_217MB",
+            displayName: "Whisper Small (English, Quantized)",
+            sizeInMB: 217,
+            description: "Quantized English small model — compact and fast",
+            speedRating: 8.0,
+            accuracyRating: 8.3,
+            language: .english
+        ),
+        WhisperModel(
+            name: "openai_whisper-medium",
+            displayName: "Whisper Medium",
+            sizeInMB: 1530,
+            description: "Excellent for multilingual and code-switching (e.g. Chinese/English mix)",
+            speedRating: 6.5,
+            accuracyRating: 8.8,
+            language: .multilingual
+        ),
+        WhisperModel(
+            name: "openai_whisper-medium.en",
+            displayName: "Whisper Medium (English)",
+            sizeInMB: 1530,
+            description: "English-optimized medium model with high accuracy",
+            speedRating: 6.5,
+            accuracyRating: 9.0,
+            language: .english
+        ),
+        WhisperModel(
+            name: "openai_whisper-large-v2",
+            displayName: "Whisper Large v2",
+            sizeInMB: 3100,
+            description: "Previous generation large model, still very capable",
+            speedRating: 5.0,
+            accuracyRating: 9.3,
+            language: .multilingual
+        ),
+        WhisperModel(
+            name: "openai_whisper-large-v2_949MB",
+            displayName: "Whisper Large v2 (Quantized)",
+            sizeInMB: 949,
+            description: "Quantized large v2 — much smaller with minimal accuracy loss",
+            speedRating: 6.0,
+            accuracyRating: 9.1,
+            language: .multilingual
+        ),
+        WhisperModel(
+            name: "openai_whisper-large-v2_turbo",
+            displayName: "Whisper Large v2 Turbo",
+            sizeInMB: 3100,
+            description: "Turbo-optimized large v2 for faster inference",
+            speedRating: 6.5,
+            accuracyRating: 9.3,
+            language: .multilingual
+        ),
+        WhisperModel(
+            name: "openai_whisper-large-v2_turbo_955MB",
+            displayName: "Whisper Large v2 Turbo (Quantized)",
+            sizeInMB: 955,
+            description: "Quantized turbo large v2 — fast and compact",
+            speedRating: 7.0,
+            accuracyRating: 9.1,
+            language: .multilingual
         ),
         WhisperModel(
             name: "openai_whisper-large-v3",
@@ -180,12 +252,113 @@ class ModelManager {
             language: .multilingual
         ),
         WhisperModel(
+            name: "openai_whisper-large-v3_947MB",
+            displayName: "Whisper Large v3 (Quantized)",
+            sizeInMB: 947,
+            description: "Quantized large v3 — great accuracy in a smaller package",
+            speedRating: 6.0,
+            accuracyRating: 9.5,
+            language: .multilingual
+        ),
+        WhisperModel(
             name: "openai_whisper-large-v3_turbo",
             displayName: "Whisper Large v3 Turbo",
             sizeInMB: 809,
             description: "Near large-model accuracy with significantly faster processing",
             speedRating: 7.5,
             accuracyRating: 9.5,
+            language: .multilingual
+        ),
+        WhisperModel(
+            name: "openai_whisper-large-v3_turbo_954MB",
+            displayName: "Whisper Large v3 Turbo (Quantized)",
+            sizeInMB: 954,
+            description: "Quantized turbo v3 — balanced speed and accuracy",
+            speedRating: 7.5,
+            accuracyRating: 9.3,
+            language: .multilingual
+        ),
+        WhisperModel(
+            name: "openai_whisper-large-v3-v20240930",
+            displayName: "Whisper Large v3 (Sep 2024)",
+            sizeInMB: 3100,
+            description: "Updated large v3 with improved multilingual performance",
+            speedRating: 5.0,
+            accuracyRating: 9.8,
+            language: .multilingual
+        ),
+        WhisperModel(
+            name: "openai_whisper-large-v3-v20240930_547MB",
+            displayName: "Whisper Large v3 Sep 2024 (Q 547MB)",
+            sizeInMB: 547,
+            description: "Heavily quantized — smallest large v3 variant",
+            speedRating: 7.0,
+            accuracyRating: 9.3,
+            language: .multilingual
+        ),
+        WhisperModel(
+            name: "openai_whisper-large-v3-v20240930_626MB",
+            displayName: "Whisper Large v3 Sep 2024 (Q 626MB)",
+            sizeInMB: 626,
+            description: "Quantized Sep 2024 large v3 — compact with great accuracy",
+            speedRating: 6.5,
+            accuracyRating: 9.5,
+            language: .multilingual
+        ),
+        WhisperModel(
+            name: "openai_whisper-large-v3-v20240930_turbo",
+            displayName: "Whisper Large v3 Sep 2024 Turbo",
+            sizeInMB: 3100,
+            description: "Latest turbo-optimized large v3 — best overall performance",
+            speedRating: 6.5,
+            accuracyRating: 9.8,
+            language: .multilingual
+        ),
+        WhisperModel(
+            name: "openai_whisper-large-v3-v20240930_turbo_632MB",
+            displayName: "Whisper Large v3 Sep 2024 Turbo (Quantized)",
+            sizeInMB: 632,
+            description: "Quantized latest turbo — excellent accuracy in ~600MB",
+            speedRating: 7.5,
+            accuracyRating: 9.5,
+            language: .multilingual
+        ),
+        
+        // Distil-Whisper Models (distilled from large v3)
+        WhisperModel(
+            name: "distil-whisper_distil-large-v3",
+            displayName: "Distil Large v3",
+            sizeInMB: 1510,
+            description: "Distilled large v3 — faster with minimal accuracy loss",
+            speedRating: 7.5,
+            accuracyRating: 9.3,
+            language: .multilingual
+        ),
+        WhisperModel(
+            name: "distil-whisper_distil-large-v3_594MB",
+            displayName: "Distil Large v3 (Quantized)",
+            sizeInMB: 594,
+            description: "Quantized distilled model — great speed/accuracy tradeoff",
+            speedRating: 8.0,
+            accuracyRating: 9.0,
+            language: .multilingual
+        ),
+        WhisperModel(
+            name: "distil-whisper_distil-large-v3_turbo",
+            displayName: "Distil Large v3 Turbo",
+            sizeInMB: 1510,
+            description: "Turbo-optimized distilled model for fastest large-class inference",
+            speedRating: 8.0,
+            accuracyRating: 9.3,
+            language: .multilingual
+        ),
+        WhisperModel(
+            name: "distil-whisper_distil-large-v3_turbo_600MB",
+            displayName: "Distil Large v3 Turbo (Quantized)",
+            sizeInMB: 600,
+            description: "Quantized turbo distilled — fastest large-class model at ~600MB",
+            speedRating: 8.5,
+            accuracyRating: 9.0,
             language: .multilingual
         ),
         


### PR DESCRIPTION
## Summary

Adds **20 missing models** from [argmaxinc/whisperkit-coreml](https://huggingface.co/argmaxinc/whisperkit-coreml) that are available for download but not listed in Pindrop's model selector.

## What's added

### 🌏 Whisper Medium (most requested)
- `openai_whisper-medium` — **Crucial for multilingual users** (e.g. Chinese/English code-switching)
- `openai_whisper-medium.en` — English-optimized medium

### Whisper Large v2 family
- `openai_whisper-large-v2`, `-v2_949MB` (quantized), `-v2_turbo`, `-v2_turbo_955MB` (quantized)

### Quantized variants (smaller downloads, similar accuracy)
- `openai_whisper-large-v3_947MB`, `-v3_turbo_954MB`
- `openai_whisper-small_216MB`, `openai_whisper-small.en_217MB`

### Whisper Large v3 September 2024 update
- `openai_whisper-large-v3-v20240930` + 4 quantized/turbo variants
- This is the latest v3 with improved multilingual performance

### Distil-Whisper (distilled from Large v3)
- `distil-whisper_distil-large-v3` + 3 quantized/turbo variants
- Great speed/accuracy tradeoff — large-class accuracy at much faster speed

## Motivation

The Medium model is the sweet spot for non-English and multilingual users. Without it, users who need Chinese, Japanese, Korean etc. have to jump from Small (483 MB) directly to Large v3 (3.1 GB). Medium at 1.5 GB fills that gap perfectly.

The quantized variants are also important — they let users with limited disk space use larger models. For example, Large v3 Sep 2024 Turbo Quantized gives excellent accuracy at only ~632 MB.

## Changes
- `Pindrop/Services/ModelManager.swift` — added 20 new `WhisperModel` entries to `availableModels`
- No other code changes needed; the existing download/delete infrastructure handles these automatically since they follow the same WhisperKit naming convention