### PR TITLE
Unify floating indicator focus tracking

### DIFF
--- a/Pindrop.xcodeproj/project.pbxproj
+++ b/Pindrop.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		AUDIOCAPS02A2B3C4D5E6F /* AudioEngineCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUDIOCAPS01A2B3C4D5E6F /* AudioEngineCapabilities.swift */; };
 		AUTOLEARNBUILD01A2B3C4D5E6F /* AutomaticDictionaryLearningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUTOLEARNFILE01A2B3C4D5E6F /* AutomaticDictionaryLearningService.swift */; };
 		AUTOLEARNTSTBUILD01A2B3C4D5E6F /* AutomaticDictionaryLearningServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUTOLEARNTSTFILE01A2B3C4D5E6F /* AutomaticDictionaryLearningServiceTests.swift */; };
+		FLOATFSTRKBUILD01A2B3C4D5E6F /* FloatingIndicatorFocusTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FLOATFSTRKFILE01A2B3C4D5E6F /* FloatingIndicatorFocusTracker.swift */; };
+		FLOATFSTRKTESTBUILD01A2B3C4D5E6F /* FloatingIndicatorFocusTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FLOATFSTRKTESTFILE01A2B3C4D5E6F /* FloatingIndicatorFocusTrackerTests.swift */; };
 		B105C906BA4047A6B066CA79 /* HotkeyManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61D78A13A5C4AAD839A3F76 /* HotkeyManagerTests.swift */; };
 		B2C3D4E5F6789012345678AB /* ModelManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D8C7B6A5F4E3D2C1B0A9F8 /* ModelManager.swift */; };
 		BC44C77F1DDD43BFAD8A88BD /* HistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDC77E732664A859279FEC9 /* HistoryStore.swift */; };
@@ -244,6 +246,8 @@
 		AUDIOCAPS01A2B3C4D5E6F /* AudioEngineCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioEngineCapabilities.swift; sourceTree = "<group>"; };
 		AUTOLEARNFILE01A2B3C4D5E6F /* AutomaticDictionaryLearningService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticDictionaryLearningService.swift; sourceTree = "<group>"; };
 		AUTOLEARNTSTFILE01A2B3C4D5E6F /* AutomaticDictionaryLearningServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticDictionaryLearningServiceTests.swift; sourceTree = "<group>"; };
+		FLOATFSTRKFILE01A2B3C4D5E6F /* FloatingIndicatorFocusTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingIndicatorFocusTracker.swift; sourceTree = "<group>"; };
+		FLOATFSTRKTESTFILE01A2B3C4D5E6F /* FloatingIndicatorFocusTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingIndicatorFocusTrackerTests.swift; sourceTree = "<group>"; };
 		B03BAE36B1E64FE6BB38D403 /* SettingsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindow.swift; sourceTree = "<group>"; };
 		B1C2D3E4F5A60718293A4B5C /* AudioDeviceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDeviceManager.swift; sourceTree = "<group>"; };
 		B534B4EDCDB5E72BC73B626F /* ReadyStepView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReadyStepView.swift; sourceTree = "<group>"; };
@@ -471,6 +475,7 @@
 				CTXADAPT02A2B3C4D5E6F /* AppContextAdapter.swift */,
 				CTXCNTR02A2B3C4D5E6F7 /* ContextEngineContracts.swift */,
 				CTXENGN02A2B3C4D5E6F /* ContextEngineService.swift */,
+				FLOATFSTRKFILE01A2B3C4D5E6F /* FloatingIndicatorFocusTracker.swift */,
 				TOASTSVCFILE01A2B3C4D5E6F /* ToastService.swift */,
 				AUTOLEARNFILE01A2B3C4D5E6F /* AutomaticDictionaryLearningService.swift */,
 				WKSPIDX01A2B3C4D5E6F /* WorkspaceFileIndexService.swift */,
@@ -606,6 +611,7 @@
 				CTXADAPTTEST02A2B3C4D5E6F /* AppContextAdapterRegistryTests.swift */,
 				ROUTESIGTEST02A2B3C4D5E6F /* PromptRoutingSignalTests.swift */,
 				CTXENGNTEST02A2B3C4D5E6F /* ContextEngineServiceTests.swift */,
+				FLOATFSTRKTESTFILE01A2B3C4D5E6F /* FloatingIndicatorFocusTrackerTests.swift */,
 				TOASTTESTFILE01A2B3C4D5E6F /* ToastServiceTests.swift */,
 				AUTOLEARNTSTFILE01A2B3C4D5E6F /* AutomaticDictionaryLearningServiceTests.swift */,
 				COORDFLW02A2B3C4D5E6F /* AppCoordinatorContextFlowTests.swift */,
@@ -947,6 +953,7 @@
 				CTXADAPTTEST01A2B3C4D5E6F /* AppContextAdapterRegistryTests.swift in Sources */,
 				ROUTESIGTEST01A2B3C4D5E6F /* PromptRoutingSignalTests.swift in Sources */,
 				CTXENGNTEST01A2B3C4D5E6F /* ContextEngineServiceTests.swift in Sources */,
+				FLOATFSTRKTESTBUILD01A2B3C4D5E6F /* FloatingIndicatorFocusTrackerTests.swift in Sources */,
 				TOASTTESTBUILD01A2B3C4D5E6F /* ToastServiceTests.swift in Sources */,
 				AUTOLEARNTSTBUILD01A2B3C4D5E6F /* AutomaticDictionaryLearningServiceTests.swift in Sources */,
 				COORDFLW01A2B3C4D5E6F /* AppCoordinatorContextFlowTests.swift in Sources */,
@@ -1054,6 +1061,7 @@
 				CTXCNTR02A2B3C4D5E6F /* ContextEngineContracts.swift in Sources */,
 				CTXADAPT01A2B3C4D5E6F /* AppContextAdapter.swift in Sources */,
 				CTXENGN01A2B3C4D5E6F /* ContextEngineService.swift in Sources */,
+				FLOATFSTRKBUILD01A2B3C4D5E6F /* FloatingIndicatorFocusTracker.swift in Sources */,
 				TOASTSVCBUILD01A2B3C4D5E6F /* ToastService.swift in Sources */,
 				AUTOLEARNBUILD01A2B3C4D5E6F /* AutomaticDictionaryLearningService.swift in Sources */,
 				WKSPIDX02A2B3C4D5E6F /* WorkspaceFileIndexService.swift in Sources */,

--- a/Pindrop/AppCoordinator.swift
+++ b/Pindrop/AppCoordinator.swift
@@ -220,6 +220,27 @@ final class AppCoordinator {
         )
     }
 
+    static func floatingIndicatorFocusTrackingMode(
+        floatingIndicatorEnabled: Bool,
+        isTemporarilyHidden: Bool,
+        selectedType: FloatingIndicatorType,
+        isRecording: Bool,
+        isProcessing: Bool
+    ) -> FloatingIndicatorTrackingMode? {
+        guard floatingIndicatorEnabled, !isTemporarilyHidden else { return nil }
+
+        if isRecording || isProcessing {
+            switch selectedType {
+            case .pill, .notch:
+                return .activeSession
+            case .bubble:
+                return nil
+            }
+        }
+
+        return selectedType == .pill ? .idlePill : nil
+    }
+
     private enum EventTapKind {
         case escape
         case modifier
@@ -265,6 +286,7 @@ final class AppCoordinator {
     let pillFloatingIndicatorController: PillFloatingIndicatorController
     let caretBubbleFloatingIndicatorController: CaretBubbleFloatingIndicatorController
     let floatingIndicatorPresenters: [FloatingIndicatorType: any FloatingIndicatorPresenting]
+    let floatingIndicatorFocusTracker: FloatingIndicatorFocusTracker
     let onboardingController: OnboardingWindowController
     let splashController: SplashWindowController
     let mainWindowController: MainWindowController
@@ -368,6 +390,9 @@ final class AppCoordinator {
         self.notesStore = NotesStore(modelContext: modelContext, aiEnhancementService: aiEnhancementService, settingsStore: settingsStore)
         self.contextCaptureService = ContextCaptureService()
         self.contextEngineService = ContextEngineService()
+        self.floatingIndicatorFocusTracker = FloatingIndicatorFocusTracker(
+            contextEngineService: contextEngineService
+        )
         self.toastWindowController = ToastWindowController()
         self.toastService = ToastService(presenter: toastWindowController)
         self.automaticDictionaryLearningService = AutomaticDictionaryLearningService(
@@ -553,6 +578,9 @@ final class AppCoordinator {
             },
             anchorProvider: { [weak self] in
                 self?.contextEngineService.captureFocusedElementAnchorRect()
+            },
+            preferredScreenProvider: { [weak self] in
+                self?.floatingIndicatorFocusTracker.preferredScreen()
             }
         )
 
@@ -1273,15 +1301,18 @@ final class AppCoordinator {
     private func updateFloatingIndicatorVisibility(previousType: FloatingIndicatorType? = nil) {
         guard !isFloatingIndicatorTemporarilyHidden() else {
             hideAllFloatingIndicators()
+            syncFloatingIndicatorFocusTracking()
             return
         }
 
         guard settingsStore.floatingIndicatorEnabled else {
             hideAllFloatingIndicators()
+            syncFloatingIndicatorFocusTracking()
             return
         }
 
         let selectedType = configuredFloatingIndicatorType()
+        syncFloatingIndicatorFocusTracking()
         
         if isRecording || isProcessing {
             if previousType != selectedType {
@@ -1331,11 +1362,28 @@ final class AppCoordinator {
         }
     }
 
+    private func syncFloatingIndicatorFocusTracking() {
+        let trackingMode = Self.floatingIndicatorFocusTrackingMode(
+            floatingIndicatorEnabled: settingsStore.floatingIndicatorEnabled,
+            isTemporarilyHidden: isFloatingIndicatorTemporarilyHidden(),
+            selectedType: configuredFloatingIndicatorType(),
+            isRecording: isRecording,
+            isProcessing: isProcessing
+        )
+
+        if let trackingMode {
+            floatingIndicatorFocusTracker.start(mode: trackingMode)
+        } else {
+            floatingIndicatorFocusTracker.stop()
+        }
+    }
+
     private func startRecordingIndicatorSession() {
-        guard settingsStore.floatingIndicatorEnabled else { return }
+        guard settingsStore.floatingIndicatorEnabled, !isFloatingIndicatorTemporarilyHidden() else { return }
 
         let selectedType = configuredFloatingIndicatorType()
         activeFloatingIndicatorType = selectedType
+        syncFloatingIndicatorFocusTracking()
         hideAllFloatingIndicators(except: selectedType)
         floatingIndicatorPresenters[selectedType]?.startRecording()
     }
@@ -1347,6 +1395,7 @@ final class AppCoordinator {
         }
 
         let activeType = activeFloatingIndicatorType ?? configuredFloatingIndicatorType()
+        syncFloatingIndicatorFocusTracking()
         floatingIndicatorPresenters[activeType]?.transitionToProcessing()
     }
 
@@ -1364,6 +1413,7 @@ final class AppCoordinator {
 
         guard settingsStore.floatingIndicatorEnabled else {
             hideAllFloatingIndicators()
+            syncFloatingIndicatorFocusTracking()
             return
         }
         updateFloatingIndicatorVisibility()
@@ -3317,6 +3367,7 @@ final class AppCoordinator {
         floatingIndicatorHiddenUntil = Date().addingTimeInterval(hideDuration)
 
         hideAllFloatingIndicators()
+        syncFloatingIndicatorFocusTracking()
 
         floatingIndicatorHiddenTask?.cancel()
         floatingIndicatorHiddenTask = Task { [weak self] in

--- a/Pindrop/Services/ContextEngineService.swift
+++ b/Pindrop/Services/ContextEngineService.swift
@@ -393,6 +393,21 @@ final class ContextEngineService {
         return rect.isEmpty ? nil : rect
     }
 
+    func captureFocusedWindowFrame() -> CGRect? {
+        guard axProvider.isProcessTrusted() else { return nil }
+        guard let appElement = axProvider.copyFrontmostApplication() else { return nil }
+        guard let focusedWindow = axProvider.elementAttribute(kAXFocusedWindowAttribute, of: appElement) else {
+            return nil
+        }
+        guard let position = axProvider.pointAttribute(kAXPositionAttribute, of: focusedWindow),
+              let size = axProvider.sizeAttribute(kAXSizeAttribute, of: focusedWindow) else {
+            return nil
+        }
+
+        let rect = CGRect(origin: position, size: size).standardized
+        return rect.isEmpty ? nil : rect
+    }
+
     func captureFocusedTextSnapshot() -> FocusedTextSnapshot? {
         guard axProvider.isProcessTrusted() else {
             Log.context.infoVisible("Focused text snapshot unavailable: accessibility permission not granted")

--- a/Pindrop/Services/FloatingIndicatorFocusTracker.swift
+++ b/Pindrop/Services/FloatingIndicatorFocusTracker.swift
@@ -1,0 +1,459 @@
+//
+//  FloatingIndicatorFocusTracker.swift
+//  Pindrop
+//
+//  Created on 2026-04-06.
+//
+
+import AppKit
+import ApplicationServices
+import Foundation
+
+enum FloatingIndicatorFocusSource: Equatable {
+    case mouse
+    case frontmostApplication
+    case focusedWindow
+    case focusedElement
+}
+
+enum FloatingIndicatorTrackingMode: Equatable {
+    case idlePill
+    case activeSession
+}
+
+struct FloatingIndicatorPlacementContext: Equatable {
+    let displayNumber: UInt32
+    let source: FloatingIndicatorFocusSource
+    let updatedAt: Date
+}
+
+@MainActor
+protocol FloatingIndicatorAXObservationSession: AnyObject {
+    func invalidate()
+}
+
+@MainActor
+protocol FloatingIndicatorMousePollingSession: AnyObject {
+    func invalidate()
+}
+
+enum FloatingIndicatorAXObservationEvent {
+    case focusedWindowChanged
+    case focusedElementChanged
+}
+
+@MainActor
+protocol FloatingIndicatorAXObserving: AnyObject {
+    func beginObservation(
+        handler: @escaping @MainActor (FloatingIndicatorAXObservationEvent) -> Void
+    ) -> (any FloatingIndicatorAXObservationSession)?
+}
+
+private func floatingIndicatorDefaultMouseDisplayNumber() -> UInt32? {
+    let displayNumber = NSScreen.screenUnderMouse().pindrop_displayNumber
+    return displayNumber == 0 ? nil : displayNumber
+}
+
+@MainActor
+private func floatingIndicatorDefaultMousePollingScheduler(
+    handler: @escaping @MainActor () -> Void
+) -> any FloatingIndicatorMousePollingSession {
+    Timer.pindrop_scheduleRepeating(interval: 0.05) { _ in
+        Task { @MainActor in
+            handler()
+        }
+    }
+}
+
+private func floatingIndicatorDefaultScreen(for displayNumber: UInt32) -> NSScreen? {
+    NSScreen.screens.first { $0.pindrop_displayNumber == displayNumber }
+}
+
+private func floatingIndicatorDefaultDisplayNumber(for rect: CGRect) -> UInt32? {
+    let standardizedRect = rect.standardized
+    guard !standardizedRect.isNull, !standardizedRect.isEmpty else { return nil }
+
+    let midpoint = CGPoint(x: standardizedRect.midX, y: standardizedRect.midY)
+    if let midpointScreen = NSScreen.screens.first(where: {
+        $0.frame.contains(midpoint) || $0.visibleFrame.contains(midpoint)
+    }) {
+        let displayNumber = midpointScreen.pindrop_displayNumber
+        return displayNumber == 0 ? nil : displayNumber
+    }
+
+    let bestIntersection = NSScreen.screens
+        .compactMap { screen -> (screen: NSScreen, area: CGFloat)? in
+            let intersection = standardizedRect.intersection(screen.frame)
+            guard !intersection.isNull, !intersection.isEmpty else { return nil }
+            return (screen, intersection.width * intersection.height)
+        }
+        .max { $0.area < $1.area }
+
+    let displayNumber = bestIntersection?.screen.pindrop_displayNumber ?? 0
+    return displayNumber == 0 ? nil : displayNumber
+}
+
+@MainActor
+final class FloatingIndicatorFocusTracker {
+    private let contextEngineService: ContextEngineService
+    private let workspaceNotificationCenter: NotificationCenter
+    private let now: () -> Date
+    private let axObservationService: any FloatingIndicatorAXObserving
+    private let mouseDisplayNumberProvider: () -> UInt32?
+    private let displayNumberForRect: (CGRect) -> UInt32?
+    private let screenResolver: (UInt32) -> NSScreen?
+    private let mousePollingScheduler: (@escaping @MainActor () -> Void) -> any FloatingIndicatorMousePollingSession
+
+    private var trackingMode: FloatingIndicatorTrackingMode?
+    private var placementContextValue: FloatingIndicatorPlacementContext?
+    private var mousePollingSession: (any FloatingIndicatorMousePollingSession)?
+    private var workspaceObserverToken: NSObjectProtocol?
+    private var axObservationSession: (any FloatingIndicatorAXObservationSession)?
+    private var lastObservedMouseDisplayNumber: UInt32?
+
+    init(
+        contextEngineService: ContextEngineService,
+        axProvider: AXProviderProtocol = SystemAXProvider(),
+        workspaceNotificationCenter: NotificationCenter = NSWorkspace.shared.notificationCenter,
+        now: @escaping () -> Date = Date.init,
+        axObservationService: (any FloatingIndicatorAXObserving)? = nil,
+        mouseDisplayNumberProvider: @escaping () -> UInt32? = floatingIndicatorDefaultMouseDisplayNumber,
+        displayNumberForRect: @escaping (CGRect) -> UInt32? = floatingIndicatorDefaultDisplayNumber(for:),
+        screenResolver: @escaping (UInt32) -> NSScreen? = floatingIndicatorDefaultScreen(for:),
+        mousePollingScheduler: @escaping (@escaping @MainActor () -> Void) -> any FloatingIndicatorMousePollingSession = floatingIndicatorDefaultMousePollingScheduler(handler:)
+    ) {
+        self.contextEngineService = contextEngineService
+        self.workspaceNotificationCenter = workspaceNotificationCenter
+        self.now = now
+        self.axObservationService = axObservationService ?? FloatingIndicatorAXObservationService(axProvider: axProvider)
+        self.mouseDisplayNumberProvider = mouseDisplayNumberProvider
+        self.displayNumberForRect = displayNumberForRect
+        self.screenResolver = screenResolver
+        self.mousePollingScheduler = mousePollingScheduler
+    }
+
+    var placementContext: FloatingIndicatorPlacementContext? {
+        placementContextValue
+    }
+
+    func start(mode: FloatingIndicatorTrackingMode) {
+        let isRestartingInNewMode = trackingMode != nil && trackingMode != mode
+        trackingMode = mode
+
+        if workspaceObserverToken == nil {
+            workspaceObserverToken = workspaceNotificationCenter.addObserver(
+                forName: NSWorkspace.didActivateApplicationNotification,
+                object: nil,
+                queue: nil
+            ) { [weak self] _ in
+                Task { @MainActor in
+                    self?.handleFrontmostApplicationActivated()
+                }
+            }
+        }
+
+        if mousePollingSession == nil {
+            mousePollingSession = mousePollingScheduler { [weak self] in
+                self?.handleMouseTick()
+            }
+        }
+
+        if axObservationSession == nil || isRestartingInNewMode {
+            installAXObservation()
+        }
+
+        lastObservedMouseDisplayNumber = mouseDisplayNumberProvider()
+
+        guard placementContextValue == nil else { return }
+
+        seedPlacement(for: mode)
+    }
+
+    func stop() {
+        trackingMode = nil
+        placementContextValue = nil
+        lastObservedMouseDisplayNumber = nil
+
+        mousePollingSession?.invalidate()
+        mousePollingSession = nil
+
+        axObservationSession?.invalidate()
+        axObservationSession = nil
+
+        if let workspaceObserverToken {
+            workspaceNotificationCenter.removeObserver(workspaceObserverToken)
+            self.workspaceObserverToken = nil
+        }
+    }
+
+    func preferredScreen() -> NSScreen? {
+        if let placementContextValue,
+           let screen = screenResolver(placementContextValue.displayNumber) {
+            return screen
+        }
+
+        guard let displayNumber = mouseDisplayNumberProvider() else { return nil }
+        return screenResolver(displayNumber)
+    }
+
+    func handleMouseTick() {
+        guard trackingMode != nil else { return }
+        guard let displayNumber = mouseDisplayNumberProvider() else { return }
+
+        defer { lastObservedMouseDisplayNumber = displayNumber }
+
+        guard let lastObservedMouseDisplayNumber else {
+            return
+        }
+
+        guard displayNumber != lastObservedMouseDisplayNumber else { return }
+        applyPlacement(
+            displayNumber: displayNumber,
+            source: .mouse,
+            updatedAt: now()
+        )
+    }
+
+    private func seedPlacement(for mode: FloatingIndicatorTrackingMode) {
+        let seededAt = now()
+
+        switch mode {
+        case .idlePill:
+            guard let displayNumber = mouseDisplayNumberProvider() else { return }
+            applyPlacement(displayNumber: displayNumber, source: .mouse, updatedAt: seededAt)
+
+        case .activeSession:
+            if let focusPlacement = resolveFocusPlacement(updatedAt: seededAt) {
+                applyPlacement(focusPlacement)
+            } else if placementContextValue == nil,
+                      let fallbackDisplayNumber = mouseDisplayNumberProvider() {
+                applyPlacement(displayNumber: fallbackDisplayNumber, source: .mouse, updatedAt: seededAt)
+            }
+        }
+    }
+
+    private func handleFrontmostApplicationActivated() {
+        guard trackingMode != nil else { return }
+        installAXObservation()
+        handleFocusEvent(source: .frontmostApplication)
+    }
+
+    private func installAXObservation() {
+        axObservationSession?.invalidate()
+        axObservationSession = axObservationService.beginObservation { [weak self] event in
+            switch event {
+            case .focusedWindowChanged:
+                self?.handleFocusEvent(source: .focusedWindow)
+            case .focusedElementChanged:
+                self?.handleFocusEvent(source: .focusedElement)
+            }
+        }
+    }
+
+    private func handleFocusEvent(source: FloatingIndicatorFocusSource) {
+        let updatedAt = now()
+
+        if let focusPlacement = resolveFocusPlacement(updatedAt: updatedAt, preferredSource: source) {
+            applyPlacement(focusPlacement)
+            return
+        }
+
+        guard placementContextValue == nil,
+              let fallbackDisplayNumber = mouseDisplayNumberProvider() else {
+            return
+        }
+
+        applyPlacement(displayNumber: fallbackDisplayNumber, source: source, updatedAt: updatedAt)
+    }
+
+    private func resolveFocusDisplayNumber() -> UInt32? {
+        if let windowFrame = contextEngineService.captureFocusedWindowFrame(),
+           let displayNumber = displayNumberForRect(windowFrame) {
+            return displayNumber
+        }
+
+        if let anchorRect = contextEngineService.captureFocusedElementAnchorRect(),
+           let displayNumber = displayNumberForRect(anchorRect) {
+            return displayNumber
+        }
+
+        return nil
+    }
+
+    private func resolveFocusPlacement(
+        updatedAt: Date,
+        preferredSource: FloatingIndicatorFocusSource? = nil
+    ) -> FloatingIndicatorPlacementContext? {
+        if let windowFrame = contextEngineService.captureFocusedWindowFrame(),
+           let displayNumber = displayNumberForRect(windowFrame) {
+            return FloatingIndicatorPlacementContext(
+                displayNumber: displayNumber,
+                source: preferredSource ?? .focusedWindow,
+                updatedAt: updatedAt
+            )
+        }
+
+        if let anchorRect = contextEngineService.captureFocusedElementAnchorRect(),
+           let displayNumber = displayNumberForRect(anchorRect) {
+            return FloatingIndicatorPlacementContext(
+                displayNumber: displayNumber,
+                source: .focusedElement,
+                updatedAt: updatedAt
+            )
+        }
+
+        return nil
+    }
+
+    private func applyPlacement(
+        _ candidate: FloatingIndicatorPlacementContext
+    ) {
+        applyPlacement(
+            displayNumber: candidate.displayNumber,
+            source: candidate.source,
+            updatedAt: candidate.updatedAt
+        )
+    }
+
+    private func applyPlacement(
+        displayNumber: UInt32,
+        source: FloatingIndicatorFocusSource,
+        updatedAt: Date
+    ) {
+        guard displayNumber != 0 else { return }
+
+        let candidate = FloatingIndicatorPlacementContext(
+            displayNumber: displayNumber,
+            source: source,
+            updatedAt: updatedAt
+        )
+
+        guard shouldAccept(candidate) else { return }
+        placementContextValue = candidate
+    }
+
+    private func shouldAccept(_ candidate: FloatingIndicatorPlacementContext) -> Bool {
+        guard let current = placementContextValue else { return true }
+        guard candidate.updatedAt >= current.updatedAt else { return false }
+
+        if candidate.displayNumber != current.displayNumber {
+            return true
+        }
+
+        return candidate.source != current.source
+    }
+
+}
+
+extension Timer: FloatingIndicatorMousePollingSession {}
+
+@MainActor
+private final class FloatingIndicatorAXObservationService: FloatingIndicatorAXObserving {
+    private let axProvider: AXProviderProtocol
+
+    init(axProvider: AXProviderProtocol) {
+        self.axProvider = axProvider
+    }
+
+    func beginObservation(
+        handler: @escaping @MainActor (FloatingIndicatorAXObservationEvent) -> Void
+    ) -> (any FloatingIndicatorAXObservationSession)? {
+        FloatingIndicatorAXObserverSession(axProvider: axProvider, handler: handler)
+    }
+}
+
+private final class FloatingIndicatorAXObserverSession: FloatingIndicatorAXObservationSession {
+    private let appElement: AXUIElement
+    private let handler: @MainActor (FloatingIndicatorAXObservationEvent) -> Void
+
+    private var observer: AXObserver?
+    private var registeredNotifications: [String] = []
+    private var isInvalidated = false
+
+    init?(
+        axProvider: AXProviderProtocol,
+        handler: @escaping @MainActor (FloatingIndicatorAXObservationEvent) -> Void
+    ) {
+        guard let appPID = axProvider.frontmostAppPID(),
+              let appElement = axProvider.copyFrontmostApplication() else {
+            return nil
+        }
+
+        self.appElement = appElement
+        self.handler = handler
+
+        var createdObserver: AXObserver?
+        let callback: AXObserverCallback = { _, _, notification, refcon in
+            guard let refcon else { return }
+            let session = Unmanaged<FloatingIndicatorAXObserverSession>.fromOpaque(refcon).takeUnretainedValue()
+            session.handleAXNotification(notification as String)
+        }
+
+        guard AXObserverCreate(appPID, callback, &createdObserver) == .success,
+              let observer = createdObserver else {
+            return nil
+        }
+
+        self.observer = observer
+
+        CFRunLoopAddSource(
+            CFRunLoopGetMain(),
+            AXObserverGetRunLoopSource(observer),
+            .defaultMode
+        )
+
+        register(notification: kAXFocusedWindowChangedNotification as String)
+        register(notification: kAXFocusedUIElementChangedNotification as String)
+    }
+
+    func invalidate() {
+        guard !isInvalidated else { return }
+        isInvalidated = true
+
+        if let observer {
+            for notification in registeredNotifications {
+                AXObserverRemoveNotification(observer, appElement, notification as CFString)
+            }
+            CFRunLoopRemoveSource(
+                CFRunLoopGetMain(),
+                AXObserverGetRunLoopSource(observer),
+                .defaultMode
+            )
+        }
+
+        registeredNotifications.removeAll()
+        observer = nil
+    }
+
+    private func register(notification: String) {
+        guard let observer else { return }
+
+        let result = AXObserverAddNotification(
+            observer,
+            appElement,
+            notification as CFString,
+            UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
+        )
+
+        guard result == .success else { return }
+        registeredNotifications.append(notification)
+    }
+
+    private func handleAXNotification(_ notification: String) {
+        guard !isInvalidated else { return }
+
+        let event: FloatingIndicatorAXObservationEvent
+        switch notification {
+        case kAXFocusedWindowChangedNotification:
+            event = .focusedWindowChanged
+        case kAXFocusedUIElementChangedNotification:
+            event = .focusedElementChanged
+        default:
+            return
+        }
+
+        Task { @MainActor in
+            self.handler(event)
+        }
+    }
+}

--- a/Pindrop/Services/FloatingIndicatorFocusTracker.swift
+++ b/Pindrop/Services/FloatingIndicatorFocusTracker.swift
@@ -164,7 +164,12 @@ final class FloatingIndicatorFocusTracker {
 
         lastObservedMouseDisplayNumber = mouseDisplayNumberProvider()
 
-        guard placementContextValue == nil else { return }
+        guard placementContextValue == nil else {
+            if isRestartingInNewMode, mode == .idlePill {
+                seedPlacement(for: mode)
+            }
+            return
+        }
 
         seedPlacement(for: mode)
     }

--- a/Pindrop/UI/FloatingIndicator.swift
+++ b/Pindrop/UI/FloatingIndicator.swift
@@ -146,7 +146,7 @@ final class FloatingIndicatorController: FloatingIndicatorPresenting {
             return
         }
         
-        guard let screen = Optional(NSScreen.screenUnderMouse()) else { return }
+        guard let screen = Optional(preferredScreen()) else { return }
         
         let notchWidth = screen.notchPanelWidth(fallback: NotchPanelMetrics.fallbackNotchWidth)
         let maxPanelWidth = max(0, screen.visibleFrame.width - (NotchPanelMetrics.horizontalInset * 2))
@@ -215,6 +215,7 @@ final class FloatingIndicatorController: FloatingIndicatorPresenting {
         stopScreenTracking()
         guard let panel = panel else { return }
         let localPanel = panel
+        let localHostingView = hostingView
 
         NSAnimationContext.runAnimationGroup({ context in
             context.duration = NotchPanelMetrics.hideDuration
@@ -223,8 +224,13 @@ final class FloatingIndicatorController: FloatingIndicatorPresenting {
         }, completionHandler: { [weak self] in
             localPanel.close()
             DispatchQueue.main.async {
-                self?.panel = nil
-                self?.hostingView = nil
+                guard let self else { return }
+                if self.panel === localPanel {
+                    self.panel = nil
+                }
+                if self.hostingView === localHostingView {
+                    self.hostingView = nil
+                }
             }
         })
     }
@@ -249,7 +255,7 @@ final class FloatingIndicatorController: FloatingIndicatorPresenting {
     
     private func startScreenTracking() {
         screenTrackingTimer?.invalidate()
-        screenTrackingTimer = Timer.pindrop_scheduleRepeating(interval: 0.5) { [weak self] _ in
+        screenTrackingTimer = Timer.pindrop_scheduleRepeating(interval: 0.05) { [weak self] _ in
             Task { @MainActor in
                 self?.checkAndUpdateScreenPosition()
             }
@@ -264,9 +270,9 @@ final class FloatingIndicatorController: FloatingIndicatorPresenting {
     
     private func checkAndUpdateScreenPosition() {
         guard let panel = panel else { return }
-        guard let currentScreen = Optional(NSScreen.screenUnderMouse()) else { return }
+        guard let currentScreen = Optional(preferredScreen()) else { return }
         
-        if lastScreen !== currentScreen {
+        if lastScreen?.pindrop_isSameDisplay(as: currentScreen) == false || lastScreen == nil {
             lastScreen = currentScreen
             
             let notchWidth = currentScreen.notchPanelWidth(fallback: NotchPanelMetrics.fallbackNotchWidth)
@@ -302,6 +308,10 @@ final class FloatingIndicatorController: FloatingIndicatorPresenting {
             )
             panel.setFrame(newFrame, display: true, animate: true)
         }
+    }
+
+    private func preferredScreen() -> NSScreen {
+        actions.preferredScreenProvider?() ?? NSScreen.screenUnderMouse()
     }
 }
 

--- a/Pindrop/UI/FloatingIndicatorShared.swift
+++ b/Pindrop/UI/FloatingIndicatorShared.swift
@@ -222,6 +222,7 @@ struct FloatingIndicatorActions {
     var selectedInputDeviceUIDProvider: (() -> String)?
     var selectedLanguageProvider: (() -> AppLanguage)?
     var anchorProvider: (() -> CGRect?)?
+    var preferredScreenProvider: (() -> NSScreen?)?
 }
 
 @MainActor

--- a/Pindrop/UI/PillFloatingIndicator.swift
+++ b/Pindrop/UI/PillFloatingIndicator.swift
@@ -115,7 +115,7 @@ final class PillFloatingIndicatorController: NSObject, ObservableObject, NSMenuD
             return
         }
 
-        guard let screen = Optional(NSScreen.screenUnderMouse()) else { return }
+        guard let screen = Optional(preferredScreen()) else { return }
 
         let state = layoutState
 
@@ -494,7 +494,7 @@ final class PillFloatingIndicatorController: NSObject, ObservableObject, NSMenuD
     private func checkAndUpdateScreenPosition() {
         guard isVisible, let panel else { return }
 
-        let currentScreen = NSScreen.screenUnderMouse()
+        let currentScreen = preferredScreen()
         if let last = lastScreen, currentScreen.pindrop_isSameDisplay(as: last) {
             return
         }
@@ -570,6 +570,7 @@ final class PillFloatingIndicatorController: NSObject, ObservableObject, NSMenuD
     func hide() {
         guard let panel = panel else { return }
         let localPanel = panel
+        let localHostingView = hostingView
 
         stopHoverIntentMonitoring()
         lastScreen = nil
@@ -587,8 +588,13 @@ final class PillFloatingIndicatorController: NSObject, ObservableObject, NSMenuD
         }, completionHandler: { [weak self] in
             localPanel.close()
             DispatchQueue.main.async {
-                self?.panel = nil
-                self?.hostingView = nil
+                guard let self else { return }
+                if self.panel === localPanel {
+                    self.panel = nil
+                }
+                if self.hostingView === localHostingView {
+                    self.hostingView = nil
+                }
             }
         })
     }
@@ -716,9 +722,13 @@ final class PillFloatingIndicatorController: NSObject, ObservableObject, NSMenuD
         Swift.max(min, Swift.min(max, value))
     }
 
+    private func preferredScreen() -> NSScreen {
+        actions.preferredScreenProvider?() ?? NSScreen.screenUnderMouse()
+    }
+
     private func refreshLayout(animated: Bool, duration: TimeInterval = 0.22) {
         guard let panel = panel else { return }
-        let screen = NSScreen.screenUnderMouse()
+        let screen = preferredScreen()
         lastScreen = screen
 
         let state = layoutState

--- a/PindropTests/AppCoordinatorContextFlowTests.swift
+++ b/PindropTests/AppCoordinatorContextFlowTests.swift
@@ -271,4 +271,80 @@ struct AppCoordinatorContextFlowTests {
             ) == false
         )
     }
+
+    @Test func floatingIndicatorFocusTrackingModeUsesIdlePillOnlyForVisiblePill() {
+        #expect(
+            AppCoordinator.floatingIndicatorFocusTrackingMode(
+                floatingIndicatorEnabled: true,
+                isTemporarilyHidden: false,
+                selectedType: .pill,
+                isRecording: false,
+                isProcessing: false
+            ) == .idlePill
+        )
+
+        #expect(
+            AppCoordinator.floatingIndicatorFocusTrackingMode(
+                floatingIndicatorEnabled: true,
+                isTemporarilyHidden: false,
+                selectedType: .notch,
+                isRecording: false,
+                isProcessing: false
+            ) == nil
+        )
+    }
+
+    @Test func floatingIndicatorFocusTrackingModeUsesActiveSessionForPillAndNotchOnly() {
+        #expect(
+            AppCoordinator.floatingIndicatorFocusTrackingMode(
+                floatingIndicatorEnabled: true,
+                isTemporarilyHidden: false,
+                selectedType: .pill,
+                isRecording: true,
+                isProcessing: false
+            ) == .activeSession
+        )
+
+        #expect(
+            AppCoordinator.floatingIndicatorFocusTrackingMode(
+                floatingIndicatorEnabled: true,
+                isTemporarilyHidden: false,
+                selectedType: .notch,
+                isRecording: false,
+                isProcessing: true
+            ) == .activeSession
+        )
+
+        #expect(
+            AppCoordinator.floatingIndicatorFocusTrackingMode(
+                floatingIndicatorEnabled: true,
+                isTemporarilyHidden: false,
+                selectedType: .bubble,
+                isRecording: true,
+                isProcessing: false
+            ) == nil
+        )
+    }
+
+    @Test func floatingIndicatorFocusTrackingModeStopsWhenDisabledOrHidden() {
+        #expect(
+            AppCoordinator.floatingIndicatorFocusTrackingMode(
+                floatingIndicatorEnabled: false,
+                isTemporarilyHidden: false,
+                selectedType: .pill,
+                isRecording: true,
+                isProcessing: false
+            ) == nil
+        )
+
+        #expect(
+            AppCoordinator.floatingIndicatorFocusTrackingMode(
+                floatingIndicatorEnabled: true,
+                isTemporarilyHidden: true,
+                selectedType: .pill,
+                isRecording: true,
+                isProcessing: false
+            ) == nil
+        )
+    }
 }

--- a/PindropTests/ContextEngineServiceTests.swift
+++ b/PindropTests/ContextEngineServiceTests.swift
@@ -239,6 +239,25 @@ struct ContextEngineServiceTests {
         #expect(rect == CGRect(x: 200, y: 300, width: 420, height: 36))
     }
 
+    @Test func captureFocusedWindowFrameReturnsFocusedWindowRect() {
+        let fixture = makeSUT()
+        fixture.mockAXProvider.setElementAttribute(kAXFocusedWindowAttribute, of: fixture.fakeAppElement, value: fixture.fakeFocusedWindow)
+        fixture.mockAXProvider.setPointAttribute(kAXPositionAttribute, of: fixture.fakeFocusedWindow, value: CGPoint(x: 40, y: 60))
+        fixture.mockAXProvider.setSizeAttribute(kAXSizeAttribute, of: fixture.fakeFocusedWindow, value: CGSize(width: 1200, height: 800))
+
+        let rect = fixture.sut.captureFocusedWindowFrame()
+        #expect(rect == CGRect(x: 40, y: 60, width: 1200, height: 800))
+    }
+
+    @Test func captureFocusedWindowFrameReturnsNilWithoutWindowGeometry() {
+        let fixture = makeSUT()
+        fixture.mockAXProvider.setElementAttribute(kAXFocusedWindowAttribute, of: fixture.fakeAppElement, value: fixture.fakeFocusedWindow)
+        fixture.mockAXProvider.setPointAttribute(kAXPositionAttribute, of: fixture.fakeFocusedWindow, value: CGPoint(x: 10, y: 10))
+
+        let rect = fixture.sut.captureFocusedWindowFrame()
+        #expect(rect == nil)
+    }
+
     @Test func secureFieldRoleSkipsValueCapture() throws {
         let fixture = makeSUT()
         fixture.mockAXProvider.isTrusted = true

--- a/PindropTests/FloatingIndicatorFocusTrackerTests.swift
+++ b/PindropTests/FloatingIndicatorFocusTrackerTests.swift
@@ -1,0 +1,351 @@
+//
+//  FloatingIndicatorFocusTrackerTests.swift
+//  PindropTests
+//
+//  Created on 2026-04-06.
+//
+
+import AppKit
+import ApplicationServices
+import Foundation
+import Testing
+
+@testable import Pindrop
+
+@MainActor
+private final class MockFloatingIndicatorAXObservationSession: FloatingIndicatorAXObservationSession {
+    private let handler: @MainActor (FloatingIndicatorAXObservationEvent) -> Void
+    private(set) var invalidateCallCount = 0
+
+    init(handler: @escaping @MainActor (FloatingIndicatorAXObservationEvent) -> Void) {
+        self.handler = handler
+    }
+
+    func emit(_ event: FloatingIndicatorAXObservationEvent) {
+        handler(event)
+    }
+
+    func invalidate() {
+        invalidateCallCount += 1
+    }
+}
+
+@MainActor
+private final class MockFloatingIndicatorAXObserver: FloatingIndicatorAXObserving {
+    private(set) var beginObservationCallCount = 0
+    private(set) var lastSession: MockFloatingIndicatorAXObservationSession?
+
+    func beginObservation(
+        handler: @escaping @MainActor (FloatingIndicatorAXObservationEvent) -> Void
+    ) -> (any FloatingIndicatorAXObservationSession)? {
+        beginObservationCallCount += 1
+        let session = MockFloatingIndicatorAXObservationSession(handler: handler)
+        lastSession = session
+        return session
+    }
+}
+
+@MainActor
+private final class MockFloatingIndicatorMousePollingSession: FloatingIndicatorMousePollingSession {
+    private(set) var invalidateCallCount = 0
+
+    func invalidate() {
+        invalidateCallCount += 1
+    }
+}
+
+@MainActor
+private final class FloatingIndicatorTrackerTestClock {
+    var current = Date(timeIntervalSinceReferenceDate: 10_000)
+
+    func now() -> Date {
+        current
+    }
+
+    func advance(by interval: TimeInterval = 1) {
+        current = current.addingTimeInterval(interval)
+    }
+}
+
+@MainActor
+private final class MutableMouseDisplayState {
+    var displayNumber: UInt32
+
+    init(displayNumber: UInt32) {
+        self.displayNumber = displayNumber
+    }
+}
+
+@MainActor
+private final class MockRectDisplayResolver {
+    private var displayNumbersByRectKey: [String: UInt32] = [:]
+
+    func setDisplayNumber(_ displayNumber: UInt32, for rect: CGRect) {
+        displayNumbersByRectKey[key(for: rect)] = displayNumber
+    }
+
+    func displayNumber(for rect: CGRect) -> UInt32? {
+        displayNumbersByRectKey[key(for: rect)]
+    }
+
+    private func key(for rect: CGRect) -> String {
+        let standardized = rect.standardized
+        return [
+            standardized.origin.x,
+            standardized.origin.y,
+            standardized.size.width,
+            standardized.size.height
+        ]
+        .map { String(format: "%.3f", $0) }
+        .joined(separator: ",")
+    }
+}
+
+@MainActor
+@Suite(.serialized)
+struct FloatingIndicatorFocusTrackerTests {
+    private struct Fixture {
+        let tracker: FloatingIndicatorFocusTracker
+        let contextEngineService: ContextEngineService
+        let axProvider: MockAXProvider
+        let fakeAppElement: AXUIElement
+        let fakeFocusedWindow: AXUIElement
+        let fakeFocusedElement: AXUIElement
+        let axObserver: MockFloatingIndicatorAXObserver
+        let mousePollingSession: MockFloatingIndicatorMousePollingSession
+        let workspaceNotificationCenter: NotificationCenter
+        let clock: FloatingIndicatorTrackerTestClock
+        let rectDisplayResolver: MockRectDisplayResolver
+        let mouseDisplayState: MutableMouseDisplayState
+    }
+
+    private func makeFixture(mouseDisplayNumber: UInt32 = 1) -> Fixture {
+        let axProvider = MockAXProvider()
+        let fakeAppElement = AXUIElementCreateApplication(77770)
+        let fakeFocusedWindow = AXUIElementCreateApplication(77771)
+        let fakeFocusedElement = AXUIElementCreateApplication(77772)
+        let axObserver = MockFloatingIndicatorAXObserver()
+        let mousePollingSession = MockFloatingIndicatorMousePollingSession()
+        let workspaceNotificationCenter = NotificationCenter()
+        let clock = FloatingIndicatorTrackerTestClock()
+        let rectDisplayResolver = MockRectDisplayResolver()
+        let mouseDisplayState = MutableMouseDisplayState(displayNumber: mouseDisplayNumber)
+
+        axProvider.isTrusted = true
+        axProvider.frontmostPID = 77770
+        axProvider.frontmostAppElement = fakeAppElement
+
+        let contextEngineService = ContextEngineService(axProvider: axProvider)
+        let tracker = FloatingIndicatorFocusTracker(
+            contextEngineService: contextEngineService,
+            axProvider: axProvider,
+            workspaceNotificationCenter: workspaceNotificationCenter,
+            now: clock.now,
+            axObservationService: axObserver,
+            mouseDisplayNumberProvider: { mouseDisplayState.displayNumber },
+            displayNumberForRect: rectDisplayResolver.displayNumber(for:),
+            screenResolver: { _ in nil },
+            mousePollingScheduler: { _ in
+                mousePollingSession
+            }
+        )
+
+        return Fixture(
+            tracker: tracker,
+            contextEngineService: contextEngineService,
+            axProvider: axProvider,
+            fakeAppElement: fakeAppElement,
+            fakeFocusedWindow: fakeFocusedWindow,
+            fakeFocusedElement: fakeFocusedElement,
+            axObserver: axObserver,
+            mousePollingSession: mousePollingSession,
+            workspaceNotificationCenter: workspaceNotificationCenter,
+            clock: clock,
+            rectDisplayResolver: rectDisplayResolver,
+            mouseDisplayState: mouseDisplayState
+        )
+    }
+
+    @Test func idlePillSeedsFromCursorDisplay() throws {
+        let fixture = makeFixture(mouseDisplayNumber: 12)
+
+        fixture.tracker.start(mode: .idlePill)
+        defer { fixture.tracker.stop() }
+
+        let placement = try #require(fixture.tracker.placementContext)
+        #expect(placement.displayNumber == 12)
+        #expect(placement.source == .mouse)
+    }
+
+    @Test func activeSessionSeedsFromFocusedWindowDisplayWhenAvailable() throws {
+        let fixture = makeFixture(mouseDisplayNumber: 2)
+        let windowRect = CGRect(x: 400, y: 200, width: 800, height: 600)
+
+        fixture.axProvider.setElementAttribute(kAXFocusedWindowAttribute, of: fixture.fakeAppElement, value: fixture.fakeFocusedWindow)
+        fixture.axProvider.setPointAttribute(kAXPositionAttribute, of: fixture.fakeFocusedWindow, value: windowRect.origin)
+        fixture.axProvider.setSizeAttribute(kAXSizeAttribute, of: fixture.fakeFocusedWindow, value: windowRect.size)
+        fixture.rectDisplayResolver.setDisplayNumber(7, for: windowRect)
+
+        fixture.tracker.start(mode: .activeSession)
+        defer { fixture.tracker.stop() }
+
+        let placement = try #require(fixture.tracker.placementContext)
+        #expect(placement.displayNumber == 7)
+        #expect(placement.source == .focusedWindow)
+    }
+
+    @Test func activeSessionFallsBackToFocusedElementDisplayWhenWindowGeometryUnavailable() throws {
+        let fixture = makeFixture(mouseDisplayNumber: 2)
+        let anchorRect = CGRect(x: 1600, y: 900, width: 8, height: 24)
+
+        fixture.axProvider.setElementAttribute(kAXFocusedWindowAttribute, of: fixture.fakeAppElement, value: fixture.fakeFocusedWindow)
+        fixture.axProvider.setElementAttribute(kAXFocusedUIElementAttribute, of: fixture.fakeAppElement, value: fixture.fakeFocusedElement)
+        fixture.axProvider.setPointAttribute(kAXPositionAttribute, of: fixture.fakeFocusedElement, value: anchorRect.origin)
+        fixture.axProvider.setSizeAttribute(kAXSizeAttribute, of: fixture.fakeFocusedElement, value: anchorRect.size)
+        fixture.rectDisplayResolver.setDisplayNumber(9, for: anchorRect)
+
+        fixture.tracker.start(mode: .activeSession)
+        defer { fixture.tracker.stop() }
+
+        let placement = try #require(fixture.tracker.placementContext)
+        #expect(placement.displayNumber == 9)
+        #expect(placement.source == .focusedElement)
+    }
+
+    @Test func activeSessionPreservesExistingPlacementWhenFocusCannotBeResolved() throws {
+        let fixture = makeFixture(mouseDisplayNumber: 4)
+
+        fixture.tracker.start(mode: .idlePill)
+        let idlePlacement = try #require(fixture.tracker.placementContext)
+        fixture.tracker.start(mode: .activeSession)
+
+        let activePlacement = try #require(fixture.tracker.placementContext)
+        #expect(activePlacement == idlePlacement)
+    }
+
+    @Test func modeTransitionDoesNotReseedExistingPlacement() throws {
+        let fixture = makeFixture(mouseDisplayNumber: 4)
+        let windowRect = CGRect(x: 1600, y: 120, width: 900, height: 700)
+
+        fixture.tracker.start(mode: .idlePill)
+        let idlePlacement = try #require(fixture.tracker.placementContext)
+
+        fixture.axProvider.setElementAttribute(kAXFocusedWindowAttribute, of: fixture.fakeAppElement, value: fixture.fakeFocusedWindow)
+        fixture.axProvider.setPointAttribute(kAXPositionAttribute, of: fixture.fakeFocusedWindow, value: windowRect.origin)
+        fixture.axProvider.setSizeAttribute(kAXSizeAttribute, of: fixture.fakeFocusedWindow, value: windowRect.size)
+        fixture.rectDisplayResolver.setDisplayNumber(7, for: windowRect)
+
+        fixture.tracker.start(mode: .activeSession)
+        defer { fixture.tracker.stop() }
+
+        let activePlacement = try #require(fixture.tracker.placementContext)
+        #expect(activePlacement == idlePlacement)
+    }
+
+    @Test func mouseDisplayChangeOverridesOlderFocusPlacement() throws {
+        let fixture = makeFixture(mouseDisplayNumber: 1)
+        let windowRect = CGRect(x: 50, y: 50, width: 640, height: 480)
+
+        fixture.axProvider.setElementAttribute(kAXFocusedWindowAttribute, of: fixture.fakeAppElement, value: fixture.fakeFocusedWindow)
+        fixture.axProvider.setPointAttribute(kAXPositionAttribute, of: fixture.fakeFocusedWindow, value: windowRect.origin)
+        fixture.axProvider.setSizeAttribute(kAXSizeAttribute, of: fixture.fakeFocusedWindow, value: windowRect.size)
+        fixture.rectDisplayResolver.setDisplayNumber(3, for: windowRect)
+
+        fixture.tracker.start(mode: .activeSession)
+        defer { fixture.tracker.stop() }
+
+        fixture.mouseDisplayState.displayNumber = 8
+        fixture.clock.advance()
+        fixture.tracker.handleMouseTick()
+
+        let placement = try #require(fixture.tracker.placementContext)
+        #expect(placement.displayNumber == 8)
+        #expect(placement.source == .mouse)
+    }
+
+    @Test func focusedWindowChangeOverridesOlderMousePlacement() throws {
+        let fixture = makeFixture(mouseDisplayNumber: 2)
+        let windowRect = CGRect(x: 1200, y: 120, width: 900, height: 700)
+
+        fixture.tracker.start(mode: .idlePill)
+        defer { fixture.tracker.stop() }
+
+        fixture.mouseDisplayState.displayNumber = 5
+        fixture.clock.advance()
+        fixture.tracker.handleMouseTick()
+
+        fixture.axProvider.setElementAttribute(kAXFocusedWindowAttribute, of: fixture.fakeAppElement, value: fixture.fakeFocusedWindow)
+        fixture.axProvider.setPointAttribute(kAXPositionAttribute, of: fixture.fakeFocusedWindow, value: windowRect.origin)
+        fixture.axProvider.setSizeAttribute(kAXSizeAttribute, of: fixture.fakeFocusedWindow, value: windowRect.size)
+        fixture.rectDisplayResolver.setDisplayNumber(11, for: windowRect)
+
+        fixture.clock.advance()
+        fixture.axObserver.lastSession?.emit(.focusedWindowChanged)
+
+        let placement = try #require(fixture.tracker.placementContext)
+        #expect(placement.displayNumber == 11)
+        #expect(placement.source == .focusedWindow)
+    }
+
+    @Test func frontmostAppActivationReinstallsObserversAndUpdatesPlacement() async throws {
+        let fixture = makeFixture(mouseDisplayNumber: 1)
+        let initialWindowRect = CGRect(x: 20, y: 20, width: 500, height: 400)
+        let activatedWindowRect = CGRect(x: 1600, y: 40, width: 500, height: 400)
+
+        fixture.axProvider.setElementAttribute(kAXFocusedWindowAttribute, of: fixture.fakeAppElement, value: fixture.fakeFocusedWindow)
+        fixture.axProvider.setPointAttribute(kAXPositionAttribute, of: fixture.fakeFocusedWindow, value: initialWindowRect.origin)
+        fixture.axProvider.setSizeAttribute(kAXSizeAttribute, of: fixture.fakeFocusedWindow, value: initialWindowRect.size)
+        fixture.rectDisplayResolver.setDisplayNumber(2, for: initialWindowRect)
+
+        fixture.tracker.start(mode: .activeSession)
+        defer { fixture.tracker.stop() }
+
+        fixture.axProvider.setPointAttribute(kAXPositionAttribute, of: fixture.fakeFocusedWindow, value: activatedWindowRect.origin)
+        fixture.axProvider.setSizeAttribute(kAXSizeAttribute, of: fixture.fakeFocusedWindow, value: activatedWindowRect.size)
+        fixture.rectDisplayResolver.setDisplayNumber(14, for: activatedWindowRect)
+
+        fixture.clock.advance()
+        fixture.workspaceNotificationCenter.post(name: NSWorkspace.didActivateApplicationNotification, object: nil)
+        await Task.yield()
+
+        let placement = try #require(fixture.tracker.placementContext)
+        #expect(fixture.axObserver.beginObservationCallCount == 2)
+        #expect(placement.displayNumber == 14)
+        #expect(placement.source == .frontmostApplication)
+    }
+
+    @Test func unresolvedAXEventsDoNotClobberExistingPlacement() throws {
+        let fixture = makeFixture(mouseDisplayNumber: 3)
+        let windowRect = CGRect(x: 90, y: 90, width: 500, height: 400)
+
+        fixture.axProvider.setElementAttribute(kAXFocusedWindowAttribute, of: fixture.fakeAppElement, value: fixture.fakeFocusedWindow)
+        fixture.axProvider.setPointAttribute(kAXPositionAttribute, of: fixture.fakeFocusedWindow, value: windowRect.origin)
+        fixture.axProvider.setSizeAttribute(kAXSizeAttribute, of: fixture.fakeFocusedWindow, value: windowRect.size)
+        fixture.rectDisplayResolver.setDisplayNumber(6, for: windowRect)
+
+        fixture.tracker.start(mode: .activeSession)
+        defer { fixture.tracker.stop() }
+
+        let initialPlacement = try #require(fixture.tracker.placementContext)
+
+        fixture.axProvider.setPointAttribute(kAXPositionAttribute, of: fixture.fakeFocusedWindow, value: .zero)
+        fixture.axProvider.setSizeAttribute(kAXSizeAttribute, of: fixture.fakeFocusedWindow, value: .zero)
+
+        fixture.clock.advance()
+        fixture.axObserver.lastSession?.emit(.focusedWindowChanged)
+
+        #expect(fixture.tracker.placementContext == initialPlacement)
+    }
+
+    @Test func activeSessionFallsBackToMousePlacementWhenAXIsUnavailable() throws {
+        let fixture = makeFixture(mouseDisplayNumber: 15)
+        fixture.axProvider.isTrusted = false
+
+        fixture.tracker.start(mode: .activeSession)
+        defer { fixture.tracker.stop() }
+
+        let placement = try #require(fixture.tracker.placementContext)
+        #expect(placement.displayNumber == 15)
+        #expect(placement.source == .mouse)
+    }
+}

--- a/PindropTests/FloatingIndicatorFocusTrackerTests.swift
+++ b/PindropTests/FloatingIndicatorFocusTrackerTests.swift
@@ -242,6 +242,29 @@ struct FloatingIndicatorFocusTrackerTests {
         #expect(activePlacement == idlePlacement)
     }
 
+    @Test func modeTransitionToIdlePillReseedsFromMousePlacement() throws {
+        let fixture = makeFixture(mouseDisplayNumber: 4)
+        let windowRect = CGRect(x: 1600, y: 120, width: 900, height: 700)
+
+        fixture.axProvider.setElementAttribute(kAXFocusedWindowAttribute, of: fixture.fakeAppElement, value: fixture.fakeFocusedWindow)
+        fixture.axProvider.setPointAttribute(kAXPositionAttribute, of: fixture.fakeFocusedWindow, value: windowRect.origin)
+        fixture.axProvider.setSizeAttribute(kAXSizeAttribute, of: fixture.fakeFocusedWindow, value: windowRect.size)
+        fixture.rectDisplayResolver.setDisplayNumber(7, for: windowRect)
+
+        fixture.tracker.start(mode: .activeSession)
+
+        let activePlacement = try #require(fixture.tracker.placementContext)
+        #expect(activePlacement.displayNumber == 7)
+        #expect(activePlacement.source == .focusedWindow)
+
+        fixture.tracker.start(mode: .idlePill)
+        defer { fixture.tracker.stop() }
+
+        let idlePlacement = try #require(fixture.tracker.placementContext)
+        #expect(idlePlacement.displayNumber == 4)
+        #expect(idlePlacement.source == .mouse)
+    }
+
     @Test func mouseDisplayChangeOverridesOlderFocusPlacement() throws {
         let fixture = makeFixture(mouseDisplayNumber: 1)
         let windowRect = CGRect(x: 50, y: 50, width: 640, height: 480)


### PR DESCRIPTION
Adds a shared FloatingIndicatorFocusTracker so the pill and notch follow the latest mouse, app activation, focused window, and focused element display signal. Wires AppCoordinator and the floating indicator presenters to a shared preferred-screen provider, extends ContextEngineService with focused-window geometry, and hardens pill/notch hide cleanup so stale animation completions do not orphan new panels. Includes regression coverage for tracker behavior, context-engine window capture, and coordinator tracking-mode rules. Verified with xcodebuild test -project Pindrop.xcodeproj -scheme Pindrop -destination "platform=macOS" -only-testing:PindropTests/FloatingIndicatorFocusTrackerTests -only-testing:PindropTests/ContextEngineServiceTests -only-testing:PindropTests/AppCoordinatorContextFlowTests.