### PR TITLE
Fix direct insert mode for non-QWERTY keyboard layouts

### DIFF
--- a/Pindrop/Services/OutputManager.swift
+++ b/Pindrop/Services/OutputManager.swift
@@ -54,6 +54,7 @@ struct ClipboardSnapshot {
 
 protocol KeySimulationProtocol {
     func postKeyEvent(keyCode: CGKeyCode, flags: CGEventFlags, keyDown: Bool) throws
+    func postCharacterEvent(character: Character, keyDown: Bool) throws
     func simulatePaste() async throws
 }
 
@@ -124,7 +125,19 @@ final class SystemKeySimulation: KeySimulationProtocol {
         event.flags = flags
         event.post(tap: .cghidEventTap)
     }
-    
+
+    func postCharacterEvent(character: Character, keyDown: Bool) throws {
+        let source = CGEventSource(stateID: .hidSystemState)
+
+        guard let event = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: keyDown) else {
+            throw OutputManagerError.textInsertionFailed
+        }
+
+        var utf16 = Array(String(character).utf16)
+        event.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: &utf16)
+        event.post(tap: .cghidEventTap)
+    }
+
     func simulatePaste() async throws {
         if try runSystemEventsPasteScript() {
             return
@@ -293,12 +306,7 @@ final class OutputManager {
             return
         }
 
-        if supportsDirectTyping(text) {
-            try await insertTextDirectly(text)
-            return
-        }
-
-        try await pasteViaClipboard(text, restoreClipboard: true)
+        try await insertTextDirectly(text)
     }
 
     private func pasteViaClipboard(_ text: String, restoreClipboard: Bool) async throws {
@@ -371,15 +379,7 @@ final class OutputManager {
     }
 
     private func insertStreamingSuffix(_ text: String) async throws {
-        if supportsDirectTyping(text) {
-            try await insertTextDirectly(text)
-        } else {
-            try await pasteViaClipboard(text, restoreClipboard: true)
-        }
-    }
-
-    private func supportsDirectTyping(_ text: String) -> Bool {
-        text.allSatisfy { getKeyCodeForCharacter($0) != nil }
+        try await insertTextDirectly(text)
     }
 
     private func deleteBackward(count: Int) async throws {
@@ -400,52 +400,9 @@ final class OutputManager {
     }
     
     private func typeCharacter(_ character: Character) async throws {
-        guard let (keyCode, modifiers) = getKeyCodeForCharacter(character) else {
-            throw OutputManagerError.textInsertionFailed
-        }
-        
-        try keySimulation.postKeyEvent(keyCode: keyCode, flags: modifiers, keyDown: true)
+        try keySimulation.postCharacterEvent(character: character, keyDown: true)
         try await Task.sleep(nanoseconds: 1_000_000)
-        try keySimulation.postKeyEvent(keyCode: keyCode, flags: modifiers, keyDown: false)
+        try keySimulation.postCharacterEvent(character: character, keyDown: false)
     }
     
-    func getKeyCodeForCharacter(_ character: Character) -> (CGKeyCode, CGEventFlags)? {
-        // Basic ASCII character mapping
-        // This is a simplified version - a production implementation would need more complete mapping
-        
-        let keyCodeMap: [Character: (CGKeyCode, CGEventFlags)] = [
-            // Lowercase letters
-            "a": (0, []), "b": (11, []), "c": (8, []), "d": (2, []), "e": (14, []),
-            "f": (3, []), "g": (5, []), "h": (4, []), "i": (34, []), "j": (38, []),
-            "k": (40, []), "l": (37, []), "m": (46, []), "n": (45, []), "o": (31, []),
-            "p": (35, []), "q": (12, []), "r": (15, []), "s": (1, []), "t": (17, []),
-            "u": (32, []), "v": (9, []), "w": (13, []), "x": (7, []), "y": (16, []),
-            "z": (6, []),
-            
-            // Uppercase letters (with shift)
-            "A": (0, .maskShift), "B": (11, .maskShift), "C": (8, .maskShift),
-            "D": (2, .maskShift), "E": (14, .maskShift), "F": (3, .maskShift),
-            "G": (5, .maskShift), "H": (4, .maskShift), "I": (34, .maskShift),
-            "J": (38, .maskShift), "K": (40, .maskShift), "L": (37, .maskShift),
-            "M": (46, .maskShift), "N": (45, .maskShift), "O": (31, .maskShift),
-            "P": (35, .maskShift), "Q": (12, .maskShift), "R": (15, .maskShift),
-            "S": (1, .maskShift), "T": (17, .maskShift), "U": (32, .maskShift),
-            "V": (9, .maskShift), "W": (13, .maskShift), "X": (7, .maskShift),
-            "Y": (16, .maskShift), "Z": (6, .maskShift),
-            
-            // Numbers
-            "0": (29, []), "1": (18, []), "2": (19, []), "3": (20, []), "4": (21, []),
-            "5": (23, []), "6": (22, []), "7": (26, []), "8": (28, []), "9": (25, []),
-            
-            // Special characters
-            " ": (49, []), // Space
-            ".": (47, []), ",": (43, []), "!": (18, .maskShift), "?": (44, .maskShift),
-            ":": (41, .maskShift), ";": (41, []), "'": (39, []), "\"": (39, .maskShift),
-            "-": (27, []), "_": (27, .maskShift), "(": (25, .maskShift), ")": (29, .maskShift),
-            "\n": (36, []), // Return/Enter
-            "\t": (48, []), // Tab
-        ]
-        
-        return keyCodeMap[character]
-    }
 }

--- a/PindropTests/OutputManagerTests.swift
+++ b/PindropTests/OutputManagerTests.swift
@@ -58,11 +58,16 @@ final class MockClipboard: ClipboardProtocol {
 
 final class MockKeySimulation: KeySimulationProtocol {
     var keyEvents: [(keyCode: CGKeyCode, flags: CGEventFlags, keyDown: Bool)] = []
+    var characterEvents: [(character: Character, keyDown: Bool)] = []
     var pasteSimulated = false
     var simulatePasteCallCount = 0
 
     func postKeyEvent(keyCode: CGKeyCode, flags: CGEventFlags, keyDown: Bool) throws {
         keyEvents.append((keyCode, flags, keyDown))
+    }
+
+    func postCharacterEvent(character: Character, keyDown: Bool) throws {
+        characterEvents.append((character, keyDown))
     }
 
     func simulatePaste() async throws {
@@ -143,7 +148,7 @@ struct OutputManagerTests {
 
         try await fixture.outputManager.updateStreamingInsertion(with: "hello")
 
-        #expect(fixture.mockKeySimulation.keyEvents.count == 10)
+        #expect(fixture.mockKeySimulation.characterEvents.count == 10)
         #expect(fixture.mockKeySimulation.pasteSimulated == false)
     }
 
@@ -153,16 +158,19 @@ struct OutputManagerTests {
 
         try await fixture.outputManager.updateStreamingInsertion(with: "hello")
         fixture.mockKeySimulation.keyEvents.removeAll()
+        fixture.mockKeySimulation.characterEvents.removeAll()
 
         try await fixture.outputManager.updateStreamingInsertion(with: "help")
 
-        #expect(fixture.mockKeySimulation.keyEvents.count == 6)
+        // 2 backspace key events (down+up) to delete "lo", then 1 character event (down+up) to type "p"
+        #expect(fixture.mockKeySimulation.keyEvents.count == 4)
         #expect(fixture.mockKeySimulation.keyEvents[0].keyCode == 51)
         #expect(fixture.mockKeySimulation.keyEvents[1].keyCode == 51)
         #expect(fixture.mockKeySimulation.keyEvents[2].keyCode == 51)
         #expect(fixture.mockKeySimulation.keyEvents[3].keyCode == 51)
-        #expect(fixture.mockKeySimulation.keyEvents[4].keyCode == 35)
-        #expect(fixture.mockKeySimulation.keyEvents[5].keyCode == 35)
+        #expect(fixture.mockKeySimulation.characterEvents.count == 2)
+        #expect(fixture.mockKeySimulation.characterEvents[0].character == "p")
+        #expect(fixture.mockKeySimulation.characterEvents[1].character == "p")
     }
 
     @Test func finishStreamingInsertionAppendsTrailingSpaceWhenRequested() async throws {
@@ -170,13 +178,13 @@ struct OutputManagerTests {
         fixture.outputManager.beginStreamingInsertion()
 
         try await fixture.outputManager.updateStreamingInsertion(with: "hello")
-        fixture.mockKeySimulation.keyEvents.removeAll()
+        fixture.mockKeySimulation.characterEvents.removeAll()
 
         try await fixture.outputManager.finishStreamingInsertion(finalText: "hello", appendTrailingSpace: true)
 
-        #expect(fixture.mockKeySimulation.keyEvents.count == 2)
-        #expect(fixture.mockKeySimulation.keyEvents[0].keyCode == 49)
-        #expect(fixture.mockKeySimulation.keyEvents[1].keyCode == 49)
+        #expect(fixture.mockKeySimulation.characterEvents.count == 2)
+        #expect(fixture.mockKeySimulation.characterEvents[0].character == " ")
+        #expect(fixture.mockKeySimulation.characterEvents[1].character == " ")
     }
 
     @Test func cancelStreamingInsertionPreservesTypedTextWhenRequested() async throws {
@@ -184,11 +192,11 @@ struct OutputManagerTests {
         fixture.outputManager.beginStreamingInsertion()
 
         try await fixture.outputManager.updateStreamingInsertion(with: "keep me")
-        let eventCountBeforeCancel = fixture.mockKeySimulation.keyEvents.count
+        let charEventCountBeforeCancel = fixture.mockKeySimulation.characterEvents.count
 
         await fixture.outputManager.cancelStreamingInsertion(removeInsertedText: false)
 
-        #expect(fixture.mockKeySimulation.keyEvents.count == eventCountBeforeCancel)
+        #expect(fixture.mockKeySimulation.characterEvents.count == charEventCountBeforeCancel)
 
         do {
             try await fixture.outputManager.updateStreamingInsertion(with: "new text")
@@ -231,16 +239,16 @@ struct OutputManagerTests {
         #expect(fixture.mockClipboard.clipboardContent == "Previous clipboard content")
     }
 
-    @Test func directInsertFallsBackToClipboardPasteForUnsupportedText() async throws {
+    @Test func directInsertHandlesEmojiWithoutClipboardFallback() async throws {
         let fixture = makeSUT(outputMode: .directInsert)
         fixture.mockClipboard.clipboardContent = "Previous clipboard content"
 
         try await fixture.outputManager.output("hello 😀")
 
-        #expect(fixture.mockKeySimulation.pasteSimulated)
-        #expect(fixture.mockClipboard.restoreCount == 1)
-        #expect(fixture.mockClipboard.copiedText == "Previous clipboard content")
+        #expect(fixture.mockKeySimulation.pasteSimulated == false)
+        #expect(fixture.mockClipboard.restoreCount == 0)
         #expect(fixture.mockClipboard.clipboardContent == "Previous clipboard content")
+        #expect(fixture.mockKeySimulation.characterEvents.count == 14) // 7 chars × 2 events
     }
 
     @Test func clipboardModeFallsBackToCopyWithoutAccessibility() async throws {
@@ -254,43 +262,18 @@ struct OutputManagerTests {
         #expect(fixture.mockClipboard.restoreCount == 0)
     }
 
-    @Test func getKeyCodeForBasicCharacters() {
-        let fixture = makeSUT()
-        let aKeyCode = fixture.outputManager.getKeyCodeForCharacter("a")
-        #expect(aKeyCode != nil)
-        #expect(aKeyCode?.0 == 0)
-        #expect(aKeyCode?.1.isEmpty == true)
+    @Test func directInsertTypesCharactersViaUnicode() async throws {
+        let fixture = makeSUT(outputMode: .directInsert)
 
-        let uppercaseAKeyCode = fixture.outputManager.getKeyCodeForCharacter("A")
-        #expect(uppercaseAKeyCode != nil)
-        #expect(uppercaseAKeyCode?.0 == 0)
-        #expect(uppercaseAKeyCode?.1.contains(.maskShift) == true)
+        try await fixture.outputManager.output("Hi!")
 
-        let oneKeyCode = fixture.outputManager.getKeyCodeForCharacter("1")
-        #expect(oneKeyCode != nil)
-        #expect(oneKeyCode?.0 == 18)
-
-        let spaceKeyCode = fixture.outputManager.getKeyCodeForCharacter(" ")
-        #expect(spaceKeyCode != nil)
-        #expect(spaceKeyCode?.0 == 49)
-    }
-
-    @Test func getKeyCodeForSpecialCharacters() {
-        let fixture = makeSUT()
-        let periodKeyCode = fixture.outputManager.getKeyCodeForCharacter(".")
-        #expect(periodKeyCode != nil)
-
-        let commaKeyCode = fixture.outputManager.getKeyCodeForCharacter(",")
-        #expect(commaKeyCode != nil)
-
-        let exclamationKeyCode = fixture.outputManager.getKeyCodeForCharacter("!")
-        #expect(exclamationKeyCode != nil)
-        #expect(exclamationKeyCode?.1.contains(.maskShift) == true)
-    }
-
-    @Test func getKeyCodeForUnsupportedCharacter() {
-        let fixture = makeSUT()
-        #expect(fixture.outputManager.getKeyCodeForCharacter("😀") == nil)
+        #expect(fixture.mockKeySimulation.characterEvents.count == 6) // 3 chars × 2 events
+        #expect(fixture.mockKeySimulation.characterEvents[0].character == "H")
+        #expect(fixture.mockKeySimulation.characterEvents[0].keyDown == true)
+        #expect(fixture.mockKeySimulation.characterEvents[1].character == "H")
+        #expect(fixture.mockKeySimulation.characterEvents[1].keyDown == false)
+        #expect(fixture.mockKeySimulation.characterEvents[2].character == "i")
+        #expect(fixture.mockKeySimulation.characterEvents[4].character == "!")
     }
 
     @Test func errorDescriptions() {
@@ -323,6 +306,7 @@ struct OutputManagerTests {
     @Test func mockKeySimulationTracksEvents() async throws {
         let mockKeySimulation = MockKeySimulation()
         #expect(mockKeySimulation.keyEvents.count == 0)
+        #expect(mockKeySimulation.characterEvents.count == 0)
         #expect(mockKeySimulation.pasteSimulated == false)
 
         try mockKeySimulation.postKeyEvent(keyCode: 0, flags: [], keyDown: true)
@@ -331,6 +315,10 @@ struct OutputManagerTests {
         #expect(mockKeySimulation.keyEvents.count == 2)
         #expect(mockKeySimulation.keyEvents[0].keyDown)
         #expect(mockKeySimulation.keyEvents[1].keyDown == false)
+
+        try mockKeySimulation.postCharacterEvent(character: "a", keyDown: true)
+        #expect(mockKeySimulation.characterEvents.count == 1)
+        #expect(mockKeySimulation.characterEvents[0].character == "a")
 
         try await mockKeySimulation.simulatePaste()
         #expect(mockKeySimulation.pasteSimulated)


### PR DESCRIPTION
Thank you for this awesome app and considering this pull request. 

Disclaimer: This fix is 100% Claude AI output. No worries if you would prefer to close it. I'm happy to push it further if something else is needed. I tested it personally, dictation now works both with QWERTY and DVORAK keyboard layout.

Changes:

Replace hardcoded QWERTY virtual key code simulation with CGEvent.keyboardSetUnicodeString for layout-independent character insertion. This fixes garbled text when using direct insert mode with Dvorak and other non-QWERTY layouts.

Also removes the clipboard fallback for emoji/unicode since the unicode approach handles all characters natively.

Fixes #49 