### PR TITLE
Refresh installed models before load to fix MODEL_NOT_INSTALLED error

### DIFF
--- a/shared/runtime-transcription/src/commonMain/kotlin/tech/watzon/pindrop/shared/runtime/transcription/LocalTranscriptionRuntime.kt
+++ b/shared/runtime-transcription/src/commonMain/kotlin/tech/watzon/pindrop/shared/runtime/transcription/LocalTranscriptionRuntime.kt
@@ -133,6 +133,8 @@ class LocalTranscriptionRuntime(
             return
         }
 
+        refreshInstalledModels()
+
         val installedRecord = installedModels.firstOrNull {
             it.modelId == modelId && it.state == ModelInstallState.INSTALLED
         }


### PR DESCRIPTION
In running this app locally I ran into errors about the models not being installed. Might be related to #26.

This simple line fixed the issue. 

TranscriptionService and ModelManager each create separate LocalTranscriptionRuntime instances. After ModelManager downloads a model, only its runtime's cache is refreshed. The TranscriptionService's runtime still has a stale (empty) installedModels list, causing every loadModel call to fail with MODEL_NOT_INSTALLED.