### PR TITLE
Fix direct insert garbling text on non-QWERTY keyboard layouts

### DIFF
--- a/Pindrop/Services/OutputManager.swift
+++ b/Pindrop/Services/OutputManager.swift
@@ -54,6 +54,7 @@ struct ClipboardSnapshot {
 
 protocol KeySimulationProtocol {
     func postKeyEvent(keyCode: CGKeyCode, flags: CGEventFlags, keyDown: Bool) throws
+    func postUnicodeCharacter(_ scalar: Unicode.Scalar) throws
     func simulatePaste() async throws
 }
 
@@ -123,6 +124,21 @@ final class SystemKeySimulation: KeySimulationProtocol {
         
         event.flags = flags
         event.post(tap: .cghidEventTap)
+    }
+
+    func postUnicodeCharacter(_ scalar: Unicode.Scalar) throws {
+        let source = CGEventSource(stateID: .hidSystemState)
+        // Use virtual key 0 as a placeholder — the Unicode string overrides what gets delivered.
+        guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true),
+              let keyUp   = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false) else {
+            throw OutputManagerError.textInsertionFailed
+        }
+        // keyboardSetUnicodeString expects UTF-16 code units (UniChar = UInt16).
+        var utf16 = Array(String(scalar).utf16)
+        keyDown.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: &utf16)
+        keyUp.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: &utf16)
+        keyDown.post(tap: .cghidEventTap)
+        keyUp.post(tap: .cghidEventTap)
     }
     
     func simulatePaste() async throws {
@@ -379,7 +395,8 @@ final class OutputManager {
     }
 
     private func supportsDirectTyping(_ text: String) -> Bool {
-        text.allSatisfy { getKeyCodeForCharacter($0) != nil }
+        // Unicode string injection handles any character, so direct typing is always supported.
+        true
     }
 
     private func deleteBackward(count: Int) async throws {
@@ -400,52 +417,11 @@ final class OutputManager {
     }
     
     private func typeCharacter(_ character: Character) async throws {
-        guard let (keyCode, modifiers) = getKeyCodeForCharacter(character) else {
-            throw OutputManagerError.textInsertionFailed
+        // Post each Unicode scalar individually so the character is delivered
+        // exactly as-is, bypassing the active keyboard layout.
+        for scalar in character.unicodeScalars {
+            try keySimulation.postUnicodeCharacter(scalar)
+            try await Task.sleep(nanoseconds: 1_000_000)
         }
-        
-        try keySimulation.postKeyEvent(keyCode: keyCode, flags: modifiers, keyDown: true)
-        try await Task.sleep(nanoseconds: 1_000_000)
-        try keySimulation.postKeyEvent(keyCode: keyCode, flags: modifiers, keyDown: false)
-    }
-    
-    func getKeyCodeForCharacter(_ character: Character) -> (CGKeyCode, CGEventFlags)? {
-        // Basic ASCII character mapping
-        // This is a simplified version - a production implementation would need more complete mapping
-        
-        let keyCodeMap: [Character: (CGKeyCode, CGEventFlags)] = [
-            // Lowercase letters
-            "a": (0, []), "b": (11, []), "c": (8, []), "d": (2, []), "e": (14, []),
-            "f": (3, []), "g": (5, []), "h": (4, []), "i": (34, []), "j": (38, []),
-            "k": (40, []), "l": (37, []), "m": (46, []), "n": (45, []), "o": (31, []),
-            "p": (35, []), "q": (12, []), "r": (15, []), "s": (1, []), "t": (17, []),
-            "u": (32, []), "v": (9, []), "w": (13, []), "x": (7, []), "y": (16, []),
-            "z": (6, []),
-            
-            // Uppercase letters (with shift)
-            "A": (0, .maskShift), "B": (11, .maskShift), "C": (8, .maskShift),
-            "D": (2, .maskShift), "E": (14, .maskShift), "F": (3, .maskShift),
-            "G": (5, .maskShift), "H": (4, .maskShift), "I": (34, .maskShift),
-            "J": (38, .maskShift), "K": (40, .maskShift), "L": (37, .maskShift),
-            "M": (46, .maskShift), "N": (45, .maskShift), "O": (31, .maskShift),
-            "P": (35, .maskShift), "Q": (12, .maskShift), "R": (15, .maskShift),
-            "S": (1, .maskShift), "T": (17, .maskShift), "U": (32, .maskShift),
-            "V": (9, .maskShift), "W": (13, .maskShift), "X": (7, .maskShift),
-            "Y": (16, .maskShift), "Z": (6, .maskShift),
-            
-            // Numbers
-            "0": (29, []), "1": (18, []), "2": (19, []), "3": (20, []), "4": (21, []),
-            "5": (23, []), "6": (22, []), "7": (26, []), "8": (28, []), "9": (25, []),
-            
-            // Special characters
-            " ": (49, []), // Space
-            ".": (47, []), ",": (43, []), "!": (18, .maskShift), "?": (44, .maskShift),
-            ":": (41, .maskShift), ";": (41, []), "'": (39, []), "\"": (39, .maskShift),
-            "-": (27, []), "_": (27, .maskShift), "(": (25, .maskShift), ")": (29, .maskShift),
-            "\n": (36, []), // Return/Enter
-            "\t": (48, []), // Tab
-        ]
-        
-        return keyCodeMap[character]
     }
 }

--- a/PindropTests/OutputManagerTests.swift
+++ b/PindropTests/OutputManagerTests.swift
@@ -58,11 +58,16 @@ final class MockClipboard: ClipboardProtocol {
 
 final class MockKeySimulation: KeySimulationProtocol {
     var keyEvents: [(keyCode: CGKeyCode, flags: CGEventFlags, keyDown: Bool)] = []
+    var unicodeCharacters: [Unicode.Scalar] = []
     var pasteSimulated = false
     var simulatePasteCallCount = 0
 
     func postKeyEvent(keyCode: CGKeyCode, flags: CGEventFlags, keyDown: Bool) throws {
         keyEvents.append((keyCode, flags, keyDown))
+    }
+
+    func postUnicodeCharacter(_ scalar: Unicode.Scalar) throws {
+        unicodeCharacters.append(scalar)
     }
 
     func simulatePaste() async throws {
@@ -143,7 +148,9 @@ struct OutputManagerTests {
 
         try await fixture.outputManager.updateStreamingInsertion(with: "hello")
 
-        #expect(fixture.mockKeySimulation.keyEvents.count == 10)
+        // Each character is posted as a Unicode scalar — 5 chars = 5 scalars.
+        #expect(fixture.mockKeySimulation.unicodeCharacters.count == 5)
+        #expect(fixture.mockKeySimulation.unicodeCharacters.map { Character($0) } == ["h", "e", "l", "l", "o"])
         #expect(fixture.mockKeySimulation.pasteSimulated == false)
     }
 
@@ -153,16 +160,15 @@ struct OutputManagerTests {
 
         try await fixture.outputManager.updateStreamingInsertion(with: "hello")
         fixture.mockKeySimulation.keyEvents.removeAll()
+        fixture.mockKeySimulation.unicodeCharacters.removeAll()
 
+        // "hello" → "help": delete "lo" (2 chars = 4 backspace key events), type "p" (1 unicode char).
         try await fixture.outputManager.updateStreamingInsertion(with: "help")
 
-        #expect(fixture.mockKeySimulation.keyEvents.count == 6)
-        #expect(fixture.mockKeySimulation.keyEvents[0].keyCode == 51)
-        #expect(fixture.mockKeySimulation.keyEvents[1].keyCode == 51)
-        #expect(fixture.mockKeySimulation.keyEvents[2].keyCode == 51)
-        #expect(fixture.mockKeySimulation.keyEvents[3].keyCode == 51)
-        #expect(fixture.mockKeySimulation.keyEvents[4].keyCode == 35)
-        #expect(fixture.mockKeySimulation.keyEvents[5].keyCode == 35)
+        #expect(fixture.mockKeySimulation.keyEvents.count == 4)
+        #expect(fixture.mockKeySimulation.keyEvents.allSatisfy { $0.keyCode == 51 })
+        #expect(fixture.mockKeySimulation.unicodeCharacters.count == 1)
+        #expect(Character(fixture.mockKeySimulation.unicodeCharacters[0]) == "p")
     }
 
     @Test func finishStreamingInsertionAppendsTrailingSpaceWhenRequested() async throws {
@@ -170,13 +176,13 @@ struct OutputManagerTests {
         fixture.outputManager.beginStreamingInsertion()
 
         try await fixture.outputManager.updateStreamingInsertion(with: "hello")
-        fixture.mockKeySimulation.keyEvents.removeAll()
+        fixture.mockKeySimulation.unicodeCharacters.removeAll()
 
         try await fixture.outputManager.finishStreamingInsertion(finalText: "hello", appendTrailingSpace: true)
 
-        #expect(fixture.mockKeySimulation.keyEvents.count == 2)
-        #expect(fixture.mockKeySimulation.keyEvents[0].keyCode == 49)
-        #expect(fixture.mockKeySimulation.keyEvents[1].keyCode == 49)
+        // Only the trailing space is new — it arrives as a Unicode scalar.
+        #expect(fixture.mockKeySimulation.unicodeCharacters.count == 1)
+        #expect(fixture.mockKeySimulation.unicodeCharacters[0] == Unicode.Scalar(" "))
     }
 
     @Test func cancelStreamingInsertionPreservesTypedTextWhenRequested() async throws {
@@ -231,15 +237,15 @@ struct OutputManagerTests {
         #expect(fixture.mockClipboard.clipboardContent == "Previous clipboard content")
     }
 
-    @Test func directInsertFallsBackToClipboardPasteForUnsupportedText() async throws {
+    @Test func directInsertTypesEmojiDirectlyWithoutClipboard() async throws {
         let fixture = makeSUT(outputMode: .directInsert)
         fixture.mockClipboard.clipboardContent = "Previous clipboard content"
 
-        try await fixture.outputManager.output("hello 😀")
+        // Unicode injection handles all characters including emoji — no clipboard fallback.
+        try await fixture.outputManager.output("hi 😀")
 
-        #expect(fixture.mockKeySimulation.pasteSimulated)
-        #expect(fixture.mockClipboard.restoreCount == 1)
-        #expect(fixture.mockClipboard.copiedText == "Previous clipboard content")
+        #expect(fixture.mockKeySimulation.pasteSimulated == false)
+        #expect(fixture.mockClipboard.restoreCount == 0)
         #expect(fixture.mockClipboard.clipboardContent == "Previous clipboard content")
     }
 
@@ -254,46 +260,7 @@ struct OutputManagerTests {
         #expect(fixture.mockClipboard.restoreCount == 0)
     }
 
-    @Test func getKeyCodeForBasicCharacters() {
-        let fixture = makeSUT()
-        let aKeyCode = fixture.outputManager.getKeyCodeForCharacter("a")
-        #expect(aKeyCode != nil)
-        #expect(aKeyCode?.0 == 0)
-        #expect(aKeyCode?.1.isEmpty == true)
-
-        let uppercaseAKeyCode = fixture.outputManager.getKeyCodeForCharacter("A")
-        #expect(uppercaseAKeyCode != nil)
-        #expect(uppercaseAKeyCode?.0 == 0)
-        #expect(uppercaseAKeyCode?.1.contains(.maskShift) == true)
-
-        let oneKeyCode = fixture.outputManager.getKeyCodeForCharacter("1")
-        #expect(oneKeyCode != nil)
-        #expect(oneKeyCode?.0 == 18)
-
-        let spaceKeyCode = fixture.outputManager.getKeyCodeForCharacter(" ")
-        #expect(spaceKeyCode != nil)
-        #expect(spaceKeyCode?.0 == 49)
-    }
-
-    @Test func getKeyCodeForSpecialCharacters() {
-        let fixture = makeSUT()
-        let periodKeyCode = fixture.outputManager.getKeyCodeForCharacter(".")
-        #expect(periodKeyCode != nil)
-
-        let commaKeyCode = fixture.outputManager.getKeyCodeForCharacter(",")
-        #expect(commaKeyCode != nil)
-
-        let exclamationKeyCode = fixture.outputManager.getKeyCodeForCharacter("!")
-        #expect(exclamationKeyCode != nil)
-        #expect(exclamationKeyCode?.1.contains(.maskShift) == true)
-    }
-
-    @Test func getKeyCodeForUnsupportedCharacter() {
-        let fixture = makeSUT()
-        #expect(fixture.outputManager.getKeyCodeForCharacter("😀") == nil)
-    }
-
-    @Test func errorDescriptions() {
+@Test func errorDescriptions() {
         #expect(OutputManagerError.accessibilityPermissionDenied.errorDescription != nil)
         #expect(OutputManagerError.emptyText.errorDescription != nil)
         #expect(OutputManagerError.clipboardWriteFailed.errorDescription != nil)


### PR DESCRIPTION
Warning: This code is all claude. It works for me though. Feel free to reject it if you don't like low effort contributions.

Replace virtual key code simulation with CGEvent Unicode string injection. Virtual key codes map to physical key positions, so they were interpreted through the active layout — producing wrong characters on Dvorak and others. Unicode injection delivers the exact character regardless of layout.

This also removes the ASCII-only restriction on direct insert: all characters including emoji are now handled without falling back to clipboard paste.