### PR TITLE
Fix model re-downloading on every launch

### DIFF
--- a/Pindrop/Services/Transcription/NativeTranscriptionAdapters.swift
+++ b/Pindrop/Services/Transcription/NativeTranscriptionAdapters.swift
@@ -286,6 +286,10 @@ final class KMPTranscriptionRuntimeBridge {
         provider: ModelManager.ModelProvider
     ) async throws -> (any TranscriptionEnginePort) {
         let backendProvider = effectiveRuntimeProvider(for: provider)
+        // Refresh installed models before loading so the runtime's internal index
+        // is up-to-date. Without this the runtime always sees an empty list and
+        // returns MODEL_NOT_INSTALLED, which causes a spurious repair/re-download.
+        _ = try? await refreshInstalledModels()
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             runtime.loadModel(modelId: TranscriptionModelId(value: modelName)) { error in
                 if let error {


### PR DESCRIPTION
Warning: This code is all claude. It works for me though. Feel free to reject it if you don't like low effort contributions. The weird thing about this is that I only have the issue when I build the app locally so; Idk what the actual bug is but it went away with this change. Probably definitely reject this pr. Idk.

TranscriptionService has its own KMPTranscriptionRuntimeBridge instance separate from ModelManager's. Its internal Kotlin runtime keeps an installedModels list that starts empty and was never refreshed before loadModel() was called. The runtime would always respond MODEL_NOT_INSTALLED, triggering attemptWhisperModelRepairAndReload which deletes and re-downloads the model on every launch.

Fix by refreshing the installed model index before each load.