### PR TITLE
Repair SwiftData stores with missing migration columns

### DIFF
--- a/Pindrop/PindropApp.swift
+++ b/Pindrop/PindropApp.swift
@@ -557,11 +557,23 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         )
 
         // SwiftData can defer opening a damaged or metadata-incompatible store
-        // until the first fetch. Validate the container here so AppDelegate's
-        // repair-and-retry path handles those stores before services retain it.
-        var healthCheck = FetchDescriptor<TranscriptionRecord>()
-        healthCheck.fetchLimit = 1
-        _ = try container.mainContext.fetch(healthCheck)
+        // until an affected entity is first fetched. Probe every current model
+        // so AppDelegate repairs the store before any service retains it.
+        func validateStoreAccess<Model: PersistentModel>(_: Model.Type) throws {
+            var healthCheck = FetchDescriptor<Model>()
+            healthCheck.fetchLimit = 1
+            _ = try container.mainContext.fetch(healthCheck)
+        }
+
+        try validateStoreAccess(TranscriptionRecord.self)
+        try validateStoreAccess(MediaFolder.self)
+        try validateStoreAccess(ParticipantProfile.self)
+        try validateStoreAccess(ParticipantTrainingEvidence.self)
+        try validateStoreAccess(WordReplacement.self)
+        try validateStoreAccess(VocabularyWord.self)
+        try validateStoreAccess(Note.self)
+        try validateStoreAccess(PromptPreset.self)
+        try validateStoreAccess(TrainingContribution.self)
         return container
     }
 
@@ -626,10 +638,17 @@ final class SwiftDataStoreRepairService {
         let sql: String
     }
 
+    private struct SchemaColumnDefinition {
+        let tableName: String
+        let name: String
+        let sql: String
+    }
+
     private struct ReferenceArtifacts {
         let metadataBlob: Data
         let modelCacheBlob: Data
         let schemaDefinitions: [SchemaObjectDefinition]
+        let columnDefinitions: [SchemaColumnDefinition]
     }
 
     private let fileManager: FileManager
@@ -701,12 +720,29 @@ final class SwiftDataStoreRepairService {
 
         let metadataVersion = try readMetadataVersionIdentifier(at: targetStoreURL)
         let referenceArtifacts = try makeReferenceArtifacts(for: inferredVersion)
-        let missingSchemaDefinitions = try withDatabase(at: targetStoreURL) { database in
+        let (missingSchemaDefinitions, missingColumnDefinitions) = try withDatabase(at: targetStoreURL) { database in
             let existingObjectNames = try fetchSchemaObjectNames(on: database)
-            return referenceArtifacts.schemaDefinitions.filter { !existingObjectNames.contains($0.name) }
+            let existingTableNames = try fetchTableNames(on: database)
+            let missingSchemaDefinitions = referenceArtifacts.schemaDefinitions.filter {
+                !existingObjectNames.contains($0.name)
+            }
+            var missingColumnDefinitions: [SchemaColumnDefinition] = []
+
+            for tableName in existingTableNames.sorted() {
+                let existingColumnNames = try fetchColumnNames(table: tableName, on: database)
+                missingColumnDefinitions.append(
+                    contentsOf: referenceArtifacts.columnDefinitions.filter {
+                        $0.tableName == tableName && !existingColumnNames.contains($0.name)
+                    }
+                )
+            }
+
+            return (missingSchemaDefinitions, missingColumnDefinitions)
         }
 
-        guard metadataVersion != inferredVersion.rawValue || !missingSchemaDefinitions.isEmpty else {
+        guard metadataVersion != inferredVersion.rawValue
+            || !missingSchemaDefinitions.isEmpty
+            || !missingColumnDefinitions.isEmpty else {
             return RepairOutcome(repaired: false, backupDirectoryURL: nil)
         }
 
@@ -715,6 +751,13 @@ final class SwiftDataStoreRepairService {
         try withDatabase(at: targetStoreURL) { database in
             try execute("BEGIN IMMEDIATE TRANSACTION", on: database)
             do {
+                for columnDefinition in missingColumnDefinitions {
+                    let tableName = quotedIdentifier(columnDefinition.tableName)
+                    try execute(
+                        "ALTER TABLE \(tableName) ADD COLUMN \(columnDefinition.sql)",
+                        on: database
+                    )
+                }
                 for schemaDefinition in missingSchemaDefinitions {
                     try execute(schemaDefinition.sql, on: database)
                 }
@@ -727,14 +770,24 @@ final class SwiftDataStoreRepairService {
             }
         }
 
-        if missingSchemaDefinitions.isEmpty {
+        if missingSchemaDefinitions.isEmpty && missingColumnDefinitions.isEmpty {
             Log.app.info(
                 "Repaired SwiftData store metadata from \(metadataVersion ?? "unknown") to \(inferredVersion.rawValue); backup: \(backupDirectoryURL.path)"
             )
         } else {
-            let recreatedNames = missingSchemaDefinitions.map(\.name).joined(separator: ", ")
+            var repairDetails: [String] = []
+            if !missingColumnDefinitions.isEmpty {
+                let addedColumns = missingColumnDefinitions
+                    .map { "\($0.tableName).\($0.name)" }
+                    .joined(separator: ", ")
+                repairDetails.append("added missing columns (\(addedColumns))")
+            }
+            if !missingSchemaDefinitions.isEmpty {
+                let recreatedNames = missingSchemaDefinitions.map(\.name).joined(separator: ", ")
+                repairDetails.append("recreated missing schema objects (\(recreatedNames))")
+            }
             Log.app.info(
-                "Repaired SwiftData store by recreating missing schema objects (\(recreatedNames)) and refreshing metadata to \(inferredVersion.rawValue); backup: \(backupDirectoryURL.path)"
+                "Repaired SwiftData store by \(repairDetails.joined(separator: " and ")) and refreshing metadata to \(inferredVersion.rawValue); backup: \(backupDirectoryURL.path)"
             )
         }
         return RepairOutcome(repaired: true, backupDirectoryURL: backupDirectoryURL)
@@ -883,10 +936,12 @@ final class SwiftDataStoreRepairService {
             }
 
             let schemaDefinitions = try fetchSchemaDefinitions(on: database)
+            let columnDefinitions = try fetchSchemaColumnDefinitions(on: database)
             return ReferenceArtifacts(
                 metadataBlob: metadataBlob,
                 modelCacheBlob: modelCacheBlob,
-                schemaDefinitions: schemaDefinitions
+                schemaDefinitions: schemaDefinitions,
+                columnDefinitions: columnDefinitions
             )
         }
     }
@@ -931,7 +986,7 @@ final class SwiftDataStoreRepairService {
 
     private func fetchColumnNames(table: String, on database: OpaquePointer) throws -> Set<String> {
         var statement: OpaquePointer?
-        let sql = "PRAGMA table_info(\(table))"
+        let sql = "PRAGMA table_info(\(quotedIdentifier(table)))"
 
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
             throw StoreRepairError.sqlite(message: lastSQLiteErrorMessage(on: database))
@@ -947,6 +1002,82 @@ final class SwiftDataStoreRepairService {
         }
 
         return columns
+    }
+
+    private func fetchSchemaColumnDefinitions(on database: OpaquePointer) throws -> [SchemaColumnDefinition] {
+        var definitions: [SchemaColumnDefinition] = []
+
+        for tableName in try fetchTableNames(on: database).sorted() {
+            var statement: OpaquePointer?
+            let sql = "PRAGMA table_info(\(quotedIdentifier(tableName)))"
+
+            guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
+                throw StoreRepairError.sqlite(message: lastSQLiteErrorMessage(on: database))
+            }
+
+            defer { sqlite3_finalize(statement) }
+
+            while sqlite3_step(statement) == SQLITE_ROW {
+                guard let namePointer = sqlite3_column_text(statement, 1) else {
+                    continue
+                }
+
+                let name = String(cString: namePointer)
+                let declaredType = sqlite3_column_text(statement, 2).map { String(cString: $0) } ?? ""
+                let isNotNull = sqlite3_column_int(statement, 3) != 0
+                let defaultValue = sqlite3_column_text(statement, 4).map { String(cString: $0) }
+                let isPrimaryKey = sqlite3_column_int(statement, 5) != 0
+                var sqlParts = [quotedIdentifier(name)]
+
+                if !declaredType.isEmpty {
+                    sqlParts.append(declaredType)
+                }
+                if isPrimaryKey {
+                    sqlParts.append("PRIMARY KEY")
+                }
+                if isNotNull {
+                    sqlParts.append("NOT NULL")
+                }
+                if let defaultValue {
+                    sqlParts.append("DEFAULT \(defaultValue)")
+                }
+
+                definitions.append(
+                    SchemaColumnDefinition(
+                        tableName: tableName,
+                        name: name,
+                        sql: sqlParts.joined(separator: " ")
+                    )
+                )
+            }
+        }
+
+        return definitions
+    }
+
+    private func fetchTableNames(on database: OpaquePointer) throws -> Set<String> {
+        var statement: OpaquePointer?
+        let sql = """
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'table'
+          AND name NOT LIKE 'sqlite_%'
+        """
+
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw StoreRepairError.sqlite(message: lastSQLiteErrorMessage(on: database))
+        }
+
+        defer { sqlite3_finalize(statement) }
+
+        var tableNames = Set<String>()
+        while sqlite3_step(statement) == SQLITE_ROW {
+            if let namePointer = sqlite3_column_text(statement, 0) {
+                tableNames.insert(String(cString: namePointer))
+            }
+        }
+
+        return tableNames
     }
 
     private func tableExists(named table: String, on database: OpaquePointer) throws -> Bool {
@@ -1091,6 +1222,10 @@ final class SwiftDataStoreRepairService {
         guard sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK else {
             throw StoreRepairError.sqlite(message: lastSQLiteErrorMessage(on: database))
         }
+    }
+
+    private func quotedIdentifier(_ identifier: String) -> String {
+        "\"\(identifier.replacingOccurrences(of: "\"", with: "\"\""))\""
     }
 
     private func withDatabase<T>(at url: URL, _ work: (OpaquePointer) throws -> T) throws -> T {

--- a/PindropTests/HistoryStoreTests.swift
+++ b/PindropTests/HistoryStoreTests.swift
@@ -2115,6 +2115,157 @@ struct HistoryStoreTests {
         try? FileManager.default.removeItem(at: directoryURL)
     }
 
+    // Regression for https://github.com/watzon/pindrop/issues/78: a store can
+    // carry current V12 metadata while still missing columns from earlier
+    // lightweight migrations. Version metadata and object-name checks alone
+    // must not cause the repair path to treat that store as healthy.
+    @Test func repairServiceRestoresCurrentMetadataStoreWithMissingColumns() throws {
+        try requireSQLiteSupport()
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let storeURL = directoryURL.appendingPathComponent("incomplete-current.store")
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let repairService = SwiftDataStoreRepairService(
+            fileManager: .default,
+            applicationSupportRootURL: directoryURL
+        )
+        let missingColumns = [
+            (table: "ZTRANSCRIPTIONRECORD", column: "ZDESTINATIONAPPNAME"),
+            (table: "ZTRANSCRIPTIONRECORD", column: "ZDESTINATIONAPPBUNDLEID"),
+            (table: "ZTRANSCRIPTIONRECORD", column: "ZWORDCOUNT"),
+            (table: "ZPARTICIPANTPROFILE", column: "ZNOTES"),
+            (table: "ZPARTICIPANTPROFILE", column: "ZISCURRENTUSER"),
+            (table: "ZPARTICIPANTPROFILE", column: "ZEMBEDDINGSPACEIDENTIFIER"),
+            (table: "ZPARTICIPANTPROFILE", column: "ZNEEDSVOICERETRAINING"),
+            (table: "ZPARTICIPANTTRAININGEVIDENCE", column: "ZEMBEDDINGSPACEIDENTIFIER"),
+            (table: "ZWORDREPLACEMENT", column: "ZMATCHMODERAWVALUE"),
+            (table: "ZWORDREPLACEMENT", column: "ZUSAGECOUNT"),
+            (table: "ZVOCABULARYWORD", column: "ZUSAGECOUNT")
+        ]
+
+        try autoreleasepool {
+            let container = try AppDelegate.makeModelContainer(at: storeURL)
+            let context = ModelContext(container)
+            let profile = ParticipantProfile(
+                normalizedName: "alice",
+                displayName: "Alice",
+                notes: "Seed notes",
+                isCurrentUser: true,
+                embeddingSpaceIdentifier: "seed-space",
+                needsVoiceRetraining: true
+            )
+
+            context.insert(
+                TranscriptionRecord(
+                    text: "Current transcription",
+                    duration: 1.0,
+                    modelUsed: "base",
+                    destinationAppName: "Notes",
+                    destinationAppBundleID: "com.apple.Notes",
+                    wordCount: 2,
+                    pipelineMetricsJSON: "{}"
+                )
+            )
+            context.insert(profile)
+            context.insert(
+                ParticipantTrainingEvidence(
+                    evidenceKey: "seed-evidence",
+                    sourceTypeRawValue: "dictation",
+                    sourceSpeakerID: "speaker-0",
+                    segmentStartTime: 0,
+                    segmentEndTime: 1,
+                    segmentDuration: 1,
+                    confidence: 0.9,
+                    embeddingData: Data([0x01]),
+                    embeddingSpaceIdentifier: "seed-space",
+                    profile: profile
+                )
+            )
+            context.insert(
+                WordReplacement(
+                    originals: ["teh"],
+                    replacement: "the",
+                    matchModeRawValue: ReplacementMatchMode.exact.rawValue,
+                    usageCount: 4
+                )
+            )
+            context.insert(VocabularyWord(word: "Pindrop", usageCount: 3))
+            try context.save()
+        }
+        try flushSQLiteStore(at: storeURL)
+
+        try withDatabase(at: storeURL) { database in
+            for missingColumn in missingColumns {
+                let tableName = quotedSQLiteIdentifier(missingColumn.table)
+                let columnName = quotedSQLiteIdentifier(missingColumn.column)
+                try execute("ALTER TABLE \(tableName) DROP COLUMN \(columnName)", on: database)
+            }
+        }
+
+        do {
+            _ = try AppDelegate.makeModelContainer(at: storeURL)
+            Issue.record("Expected current container health check to fail before repair")
+        } catch {
+            #expect(!error.localizedDescription.isEmpty)
+        }
+
+        let outcome = try repairService.repairIfNeeded(storeURL: storeURL)
+        #expect(outcome.repaired)
+        #expect(outcome.backupDirectoryURL != nil)
+
+        let repairedContainer = try AppDelegate.makeModelContainer(at: storeURL)
+        let repairedContext = ModelContext(repairedContainer)
+        let records = try repairedContext.fetch(FetchDescriptor<TranscriptionRecord>())
+        let profiles = try repairedContext.fetch(FetchDescriptor<ParticipantProfile>())
+        let evidence = try repairedContext.fetch(FetchDescriptor<ParticipantTrainingEvidence>())
+        let replacements = try repairedContext.fetch(FetchDescriptor<WordReplacement>())
+        let vocabulary = try repairedContext.fetch(FetchDescriptor<VocabularyWord>())
+
+        #expect(records.count == 1)
+        #expect(records.first?.destinationAppName == nil)
+        #expect(records.first?.destinationAppBundleID == nil)
+        #expect(records.first?.wordCount == nil)
+        #expect(profiles.count == 1)
+        #expect(profiles.first?.notes == nil)
+        #expect(profiles.first?.isCurrentUser == false)
+        #expect(profiles.first?.embeddingSpaceIdentifier == nil)
+        #expect(profiles.first?.needsVoiceRetraining == false)
+        #expect(evidence.count == 1)
+        #expect(evidence.first?.embeddingSpaceIdentifier == nil)
+        #expect(replacements.count == 1)
+        #expect(replacements.first?.matchModeRawValue == nil)
+        #expect(replacements.first?.usageCount == 0)
+        #expect(vocabulary.count == 1)
+        #expect(vocabulary.first?.usageCount == 0)
+    }
+
+    @Test func productionHealthCheckRejectsMissingNonTranscriptionColumn() throws {
+        try requireSQLiteSupport()
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let storeURL = directoryURL.appendingPathComponent("incomplete-dictionary.store")
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        try autoreleasepool {
+            let container = try AppDelegate.makeModelContainer(at: storeURL)
+            let context = ModelContext(container)
+            context.insert(VocabularyWord(word: "Pindrop", usageCount: 3))
+            try context.save()
+        }
+        try flushSQLiteStore(at: storeURL)
+
+        try withDatabase(at: storeURL) { database in
+            try execute("ALTER TABLE ZVOCABULARYWORD DROP COLUMN ZUSAGECOUNT", on: database)
+        }
+
+        do {
+            _ = try AppDelegate.makeModelContainer(at: storeURL)
+            Issue.record("Expected production health check to reject the incomplete dictionary table")
+        } catch {
+            #expect(!error.localizedDescription.isEmpty)
+        }
+    }
+
     // Regression for https://github.com/watzon/pindrop/issues/76: the old
     // repair path stamped V7+ stores with metadata built from unversioned
     // current models (version identifier 1.0.0, stale entity set), after which
@@ -2543,6 +2694,10 @@ struct HistoryStoreTests {
         guard sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK else {
             throw sqliteError(on: database)
         }
+    }
+
+    private func quotedSQLiteIdentifier(_ identifier: String) -> String {
+        "\"\(identifier.replacingOccurrences(of: "\"", with: "\"\""))\""
     }
 
     private func withDatabase<T>(at url: URL, _ work: (OpaquePointer) throws -> T) throws -> T {


### PR DESCRIPTION
I encountered the database failure described in #78 after upgrading to 1.22.4. I have really enjoyed using Pindrop as an alternative to cloud speech-to-text, so I wanted to contribute something. I asked Codex to investigate the repository and prepare a fix. I reviewed the changes and tested them against my affected store: the patched build repaired it, and the unmodified 1.22.4 release could then open and use the same store normally. The issue, as Codex explains below, involved missing columns in existing tables. Codex expanded the startup health check to detect schema failures across all current models, added column-level schema validation to the existing repair guard, and extended the repair path to restore missing columns. Codex’s full write-up is included below.

—roborule

## Summary

This extends the existing startup repair path to detect and restore missing SwiftData-generated columns even when the store metadata already reports the current schema version.

It also validates every model in the production schema during startup, so an incomplete table is detected before the `ModelContainer` is retained by application services.

## Root cause

The affected store was valid at the SQLite level, and its metadata reported the current model identifier (`V1.0.11`). It also contained `ZPIPELINEMETRICSJSON`, which caused the existing shape-based inference to classify it as V12.

However, its physical tables were missing 11 columns introduced by earlier lightweight migrations. Because the metadata version matched the inferred version and all expected schema objects existed, `repairIfNeeded` treated the store as healthy without comparing the individual table columns.

The existing startup health check also fetched only `TranscriptionRecord`. That could expose failures in the transcription table, but not missing columns first accessed through participant, dictionary, vocabulary, or other model paths.

## Implementation

- Probe all nine current SwiftData models when creating the production container, forcing deferred schema errors into the existing repair-and-retry path during startup.
- Build a pristine reference store from the exact inferred `VersionedSchema`.
- Read and compare the reference and target table-column definitions in addition to the existing metadata and schema-object checks.
- Restore missing columns using definitions derived from the reference store rather than hard-coding the 11 columns reported in #78.
- Apply column additions, missing schema-object recreation, and metadata/model-cache refresh inside the existing transaction, with rollback on failure.
- Back up the store and its WAL/SHM artifacts through the existing backup mechanism before making changes.
- Quote dynamic SQLite identifiers used during schema inspection and repair.

This remains confined to the existing emergency store-repair boundary. Normal application persistence continues to use SwiftData.

## Tests

Added regression coverage that:

- creates a real file-backed V12 store;
- removes the 11 columns reported in #78 while retaining V12 metadata;
- verifies that the production container rejects the incomplete store;
- repairs and reopens it;
- fetches all affected model types;
- confirms existing rows survive and newly restored fields receive their schema defaults; and
- verifies that a missing non-transcription column is detected during startup.

Local results:

- `just build-unsigned`: passed (`BUILD SUCCEEDED`)
- `HistoryStoreTests`: passed, including both new regression tests
- Full `just test-unsigned`: 1,341 tests ran across 100 suites. Three timing-sensitive tests outside the changed persistence code failed:
  - `AudioPCMFileStorageTests.exhaustedSlabPoolRejectsThenRecyclesInWriteOrder`
  - `AutomaticDictionaryLearningServiceTests.testSessionCanLearnMultipleCorrectionsWithinSameObservation`
  - `AutomaticDictionaryLearningServiceTests.testMergedSplitWordCorrectionPersistsExactlyOnce`

Those tests rely on fixed 25–60 ms scheduling windows and failed under full-suite load. No persistence or `HistoryStoreTests` test failed.

## Manual validation

The patched build opened the affected store and loaded its existing data. After that in-place repair, the unmodified Pindrop 1.22.4 build also opened and used the same store normally.

Fixes #78